### PR TITLE
Correct the format of the README in UI directory

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -1,6 +1,8 @@
 ## Configuration
 
-| `PLAYGROUND_UI_ROOT`    | **required** |                 | The path to the HTML, CSS, and Javascript files                         |
-| `PLAYGROUND_UI_ADDRESS` |              |       127.0.0.1 | The address to listen on                                                |
-| `PLAYGROUND_UI_PORT`    |              |            5000 | The port to listen on                                                   |
-| `TMPDIR`                |              | system-provided | Where compilation artifacts will be saved. Must be accessible to Docker |
+| Key                     | Required  | Default Value   | Description                                                             |
+| ------------------------|-----------|-----------------|-------------------------------------------------------------------------|
+| `PLAYGROUND_UI_ROOT`    | **Yes**   |                 | The path to the HTML, CSS, and Javascript files                         |
+| `PLAYGROUND_UI_ADDRESS` | No        |       127.0.0.1 | The address to listen on                                                |
+| `PLAYGROUND_UI_PORT`    | No        |            5000 | The port to listen on                                                   |
+| `TMPDIR`                | No        | system-provided | Where compilation artifacts will be saved. Must be accessible to Docker |


### PR DESCRIPTION
I found that the README file in the UI directory is not able to be correctly rendered on Github. I guessed you might want to put a table in the file.

So I corrected the format of the table in order to make it display correctly.