### PR TITLE
Create a vendor chunk

### DIFF
--- a/ui/frontend/webpack.config.js
+++ b/ui/frontend/webpack.config.js
@@ -4,15 +4,19 @@ var ExtractTextPlugin = require("extract-text-webpack-plugin");
 var CompressionPlugin = require("compression-webpack-plugin");
 var autoprefixer = require('autoprefixer');
 
+const thisPackage = require('./package.json');
+const vendorLibraries = Object.keys(thisPackage.dependencies);
+
 module.exports = {
-  entry: [
-    './index.js',
-    './index.scss'
-  ],
+  entry: {
+    app: ['./index.js', './index.scss'],
+    vendor: vendorLibraries,
+  },
 
   output: {
     path: './build',
-    filename: 'index-[hash].js'
+    filename: '[name]-[chunkhash].js',
+    chunkFilename: '[chunkhash].js'
   },
 
   resolve: {
@@ -36,10 +40,14 @@ module.exports = {
   plugins: [
     new HtmlWebpackPlugin({
       title: "Rust Playground",
-      template: 'index.ejs'
+      template: 'index.ejs',
+      chunksSortMode: 'dependency',
     }),
-    new ExtractTextPlugin("styles-[hash].css"),
-    new webpack.EnvironmentPlugin(["NODE_ENV"])
+    new ExtractTextPlugin("styles-[chunkhash].css"),
+    new webpack.EnvironmentPlugin(["NODE_ENV"]),
+    new webpack.optimize.CommonsChunkPlugin({
+      names: ['vendor', 'manifest'],
+    }),
   ],
 
   postcss: function () {


### PR DESCRIPTION
This will allow us to load the entire brace library to get all the
themes and keyboard handlers without overly bloating the app chunk.

This is complicated because the vendor chunk includes the manifest by
default. Since the manifest changes every time the application code
changes, that's not very useful! Large thanks go to [SurviveJS] for
pointers towards the proper setup.

[SurviveJS]: http://survivejs.com/webpack/building-with-webpack/splitting-bundles/