### PR TITLE
Make `--pids-limit` a default feature

### DIFF
--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -4,6 +4,10 @@ name = "ui"
 version = "0.1.0"
 build = "build.rs"
 
+[features]
+default = ['fork-bomb-prevention']
+fork-bomb-prevention = []
+
 [build-dependencies]
 serde_codegen = "0.7.0"
 

--- a/ui/src/sandbox.rs
+++ b/ui/src/sandbox.rs
@@ -199,10 +199,13 @@ impl Sandbox {
             .args(&["--net", "none"])
             .args(&["--memory", "256m"])
             .args(&["--memory-swap", "320m"])
-            .args(&["--pids-limit", "512"])
             .args(&["--env", "PLAYGROUND_TIMEOUT=10"])
             .args(&["--env", "RUST_NEW_ERROR_FORMAT=true"]);
 
+        if cfg!(feature = "fork-bomb-prevention") {
+            cmd.args(&["--pids-limit", "512"]);
+        }
+        
         cmd
     }
 }


### PR DESCRIPTION
That way it is possible to not use this flag by building like so:

`cargo build --no-default-features`

This is useful for local sandbox installations running on a different
OS which doesn't directly support limiting PIDs, or which works
differently in that regards.

I am using coreOS for example, but admittedly also didn't try
to find a way to make it work.