### PR TITLE
Correctly require node-zopfli

### DIFF
--- a/ui/frontend/package.json
+++ b/ui/frontend/package.json
@@ -39,6 +39,7 @@
     "glob": "^7.0.5",
     "html-webpack-plugin": "^2.22.0",
     "node-sass": "^3.8.0",
+    "node-zopfli": "^1.3.4",
     "normalize.css": "^4.2.0",
     "postcss-loader": "^0.9.1",
     "redux-devtools": "^3.3.1",
@@ -55,9 +56,5 @@
     "watch": "webpack --progress --colors --watch"
   },
   "author": "",
-  "license": "MIT",
-  "optionalDependencies": {
-    "fsevents": "^1.0.14",
-    "node-zopfli": "^2.0.1"
-  }
+  "license": "MIT"
 }

--- a/ui/frontend/yarn.lock
+++ b/ui/frontend/yarn.lock
@@ -1665,7 +1665,7 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
 
-fsevents, fsevents@^1.0.0:
+fsevents@^1.0.0:
   version "1.0.14"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.0.14.tgz#558e8cc38643d8ef40fe45158486d0d25758eee4"
   dependencies:
@@ -2630,15 +2630,6 @@ node-sass@^3.8.0:
 node-uuid@~1.4.7:
   version "1.4.7"
   resolved "https://registry.yarnpkg.com/node-uuid/-/node-uuid-1.4.7.tgz#6da5a17668c4b3dd59623bda11cf7fa4c1f60a6f"
-
-node-zopfli:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/node-zopfli/-/node-zopfli-2.0.1.tgz#31c0a4905644e4c96a3047638df334b4533d69f8"
-  dependencies:
-    commander "^2.8.1"
-    defaults "^1.0.2"
-    nan "^2.0.0"
-    node-pre-gyp "^0.6.4"
 
 node-zopfli@^1.3.4:
   version "1.4.0"


### PR DESCRIPTION
Although it's an optional dependency of upstream, we always want to use
it, so it's not optional for us.