### PR TITLE
Add futures crate to playground.

### DIFF
--- a/compiler/base/Cargo.toml
+++ b/compiler/base/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
+authors = ["The Rust Playground"]
 name = "playground"
 version = "0.0.1"
-authors = ["The Rust Playground"]
 
 [dependencies]
 advapi32-sys = "0.2.0"
@@ -20,6 +20,7 @@ dtoa = "0.4.1"
 either = "1.1.0"
 env_logger = "0.4.2"
 flate2 = "0.2.17"
+futures = "0.1.13"
 gcc = "0.3.45"
 gdi32-sys = "0.2.0"
 getopts = "0.2.14"


### PR DESCRIPTION
I don't know what your policy is for adding more crates but it seems like a good idea to have futures since it underpins the async ecosystem.