### PR TITLE
launch sandbox with --cap-drop=ALL and --security-opt=no-new-privileges

### DIFF
--- a/ui/src/sandbox.rs
+++ b/ui/src/sandbox.rs
@@ -217,6 +217,8 @@ impl Sandbox {
             .arg("--rm")
             .arg("--volume").arg(&mount_input_file)
             .arg("--volume").arg(&mount_output_dir)
+            .arg("--cap-drop=ALL")
+            .arg("--security-opt=no-new-privileges")
             .args(&["--workdir", "/playground"])
             .args(&["--net", "none"])
             .args(&["--memory", "256m"])


### PR DESCRIPTION
Adding these arguments should make it significantly more difficult to break out of the sandbox.

Documentation links:
 - https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities
 - http://www.projectatomic.io/blog/2016/03/no-new-privs-docker/

Note that play.rust-lang.org [already uses these options](https://github.com/rust-lang/rust-playpen/blob/ac799f6f69389ca68bbc52f46a8956938c06317e/src/docker.rs#L22-L26).