### PR TITLE
Cors Again

### DIFF
--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -19,6 +19,7 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 url = "1.4.0"
+corsware = "0.1.1"
 
 [dependencies.playground-middleware]
 git = "https://github.com/integer32llc/playground-middleware"


### PR DESCRIPTION
This is a sequel to #114 . After your suggestions I had a look at existing CORS libraries for Iron to see if I could use them to make a more correct implementation of CORS for the playground. I concluded that there was definitely room for a more ambitious CORS library, so I totally rabbit-holed and went ahead and wrote it myself. 

In order to minimize the amount of CORS code in the playground, I used a single config for all endpoints.