### PR TITLE
Add configurable split behaviour

### DIFF
--- a/ui/frontend/Configuration.jsx
+++ b/ui/frontend/Configuration.jsx
@@ -9,6 +9,7 @@ import {
   changeEditor,
   changeKeybinding,
   changeTheme,
+  changeOrientation,
   toggleConfiguration,
 } from './actions';
 
@@ -44,6 +45,7 @@ class Configuration extends PureComponent {
   onChangeEditor = e => this.props.changeEditor(e.target.value);
   onChangeKeybinding = e => this.props.changeKeybinding(e.target.value);
   onChangeTheme = e => this.props.changeTheme(e.target.value);
+  onChangeOrientation = e => this.props.changeOrientation(e.target.value);
   onKeyup = e => {
     if (e.keyCode === ESCAPE_KEYCODE && !e.defaultPrevented) {
       e.preventDefault();
@@ -60,7 +62,7 @@ class Configuration extends PureComponent {
   }
 
   render() {
-    const { editor, keybinding, theme, toggleConfiguration } = this.props;
+    const { editor, keybinding, theme, orientation, toggleConfiguration } = this.props;
 
     const advancedEditor = editor === 'advanced';
 
@@ -96,6 +98,15 @@ class Configuration extends PureComponent {
 
         {themeSelect}
 
+        <ConfigurationSelect what="orientation"
+                             label="Split Orientation"
+                             defaultValue={orientation}
+                             onChange={this.onChangeOrientation}>
+          <option value="automatic">Automatic</option>
+          <option value="horizontal">Horizontal</option>
+          <option value="vertical">Vertical</option>
+        </ConfigurationSelect>
+
         <div className="configuration-actions">
           <button onClick={toggleConfiguration}>Done</button>
         </div>
@@ -108,20 +119,23 @@ Configuration.propTypes = {
   changeEditor: PropTypes.func.isRequired,
   changeKeybinding: PropTypes.func.isRequired,
   changeTheme: PropTypes.func.isRequired,
+  changeOrientation: PropTypes.func.isRequired,
   editor: PropTypes.string.isRequired,
   keybinding: PropTypes.string.isRequired,
   theme: PropTypes.string.isRequired,
+  orientation: PropTypes.string.isRequired,
   toggleConfiguration: PropTypes.func.isRequired,
 };
 
-const mapStateToProps = ({ configuration: { editor, keybinding, theme } }) => (
-  { editor, keybinding, theme }
+const mapStateToProps = ({ configuration: { editor, keybinding, theme, orientation } }) => (
+  { editor, keybinding, theme, orientation }
 );
 
 const mapDispatchToProps = dispatch => ({
   changeEditor: editor => dispatch(changeEditor(editor)),
   changeKeybinding: keybinding => dispatch(changeKeybinding(keybinding)),
   changeTheme: theme => dispatch(changeTheme(theme)),
+  changeOrientation: orientation => dispatch(changeOrientation(orientation)),
   toggleConfiguration: () => dispatch(toggleConfiguration()),
 });
 

--- a/ui/frontend/Playground.jsx
+++ b/ui/frontend/Playground.jsx
@@ -19,10 +19,12 @@ function ConfigurationModal() {
 
 class Playground extends React.Component {
   render() {
-    const { showConfig, focus } = this.props;
+    const { showConfig, focus, splitOrientation } = this.props;
 
     const config = showConfig ? <ConfigurationModal /> : null;
     const outputFocused = focus ? 'playground-output-focused' : '';
+    const splitClass = 'playground-split';
+    const orientation = splitClass + '-' + splitOrientation;
 
     return (
       <div>
@@ -31,11 +33,13 @@ class Playground extends React.Component {
           <div className="playground-header">
             <Header />
           </div>
-          <div className="playground-editor">
-            <Editor />
-          </div>
-          <div className={`playground-output ${outputFocused}`}>
-            <Output />
+          <div className={`${splitClass} ${orientation}`}>
+            <div className="playground-editor">
+              <Editor />
+            </div>
+            <div className={`playground-output ${outputFocused}`}>
+              <Output />
+            </div>
           </div>
         </div>
       </div>
@@ -60,10 +64,11 @@ class Playground extends React.Component {
 Playground.propTypes = {
   focus: PropTypes.string,
   showConfig: PropTypes.bool.isRequired,
+  splitOrientation: PropTypes.string.isRequired,
 };
 
-const mapStateToProps = ({ configuration: { shown: showConfig }, output: { meta: { focus } } }) => (
-  { showConfig, focus }
+const mapStateToProps = ({ configuration: { shown: showConfig, orientation: splitOrientation }, output: { meta: { focus } } }) => (
+  { showConfig, focus, splitOrientation }
 );
 
 const ConnectedPlayground = connect(

--- a/ui/frontend/actions.js
+++ b/ui/frontend/actions.js
@@ -28,6 +28,7 @@ export function navigateToHelp() {
 export const CHANGE_EDITOR = 'CHANGE_EDITOR';
 export const CHANGE_KEYBINDING = 'CHANGE_KEYBINDING';
 export const CHANGE_THEME = 'CHANGE_THEME';
+export const CHANGE_ORIENTATION = 'CHANGE_ORIENTATION';
 export const CHANGE_CHANNEL = 'CHANGE_CHANNEL';
 export const CHANGE_MODE = 'CHANGE_MODE';
 export const CHANGE_FOCUS = 'CHANGE_FOCUS';
@@ -42,6 +43,10 @@ export function changeKeybinding(keybinding) {
 
 export function changeTheme(theme) {
   return { type: CHANGE_THEME, theme };
+}
+
+export function changeOrientation(orientation) {
+  return { type: CHANGE_ORIENTATION, orientation }
 }
 
 export function changeChannel(channel) {

--- a/ui/frontend/index.scss
+++ b/ui/frontend/index.scss
@@ -31,12 +31,77 @@ body {
     font-family: $primary-font;
 }
 
+@mixin split-first-child() {
+    // the first child, i.e. the editor has the border already
+    margin-top: 0;
+    margin-bottom: 0;
+    margin-left: 0;
+}
+
+@mixin split-all-children() {
+    // space between the split
+    margin-left: 0.5em;
+
+    // FIXME: remove this, when the output-rules are 'aware' of the orientation
+    //        (this disables the extra margin-top for the spacing between editor
+    //        and output in the horizontal split mode)
+    margin-top: -0.2em;
+
+    // for the border of the editor
+    margin-bottom: 4px;
+}
+
 .playground {
     display: flex;
     height: 100vh;
     flex-direction: column;
 
     padding-bottom: 1em;
+
+    &-split {
+        display: flex;
+        height: 100vh;
+
+        &-automatic {
+            @media screen and (max-width: 1600px) {
+                flex-direction: column;
+            }
+
+            @media screen and (min-width: 1600px) {
+                flex-direction: row;
+            }
+        }
+
+        &-horizontal {
+            flex-direction: column;
+        }
+
+        &-vertical {
+            flex-direction: row;
+        }
+
+        &-vertical > *:first-child {
+            @include split-first-child();
+        }
+
+        // automatic vertical
+        &-automatic > *:first-child {
+            @media screen and (min-width: 1600px) {
+                @include split-first-child();
+            }
+        }
+
+        &-vertical > * {
+            @include split-all-children();
+        }
+
+        // automatic vertical
+        &-automatic > * {
+            @media screen and (min-width: 1600px) {
+                @include split-all-children();
+            }
+        }
+    }
 
     &-editor {
         flex: 1 1 auto;

--- a/ui/frontend/local_storage.js
+++ b/ui/frontend/local_storage.js
@@ -8,6 +8,7 @@ export function serialize(state) {
       editor: state.configuration.editor,
       keybinding: state.configuration.keybinding,
       theme: state.configuration.theme,
+      orientation: state.configuration.orientation,
     },
     code: state.code,
   });
@@ -24,6 +25,7 @@ export function deserialize(savedState) {
       editor: parsedState.configuration.editor || defaultConfiguration.editor,
       keybinding: parsedState.configuration.keybinding || defaultConfiguration.keybinding,
       theme: parsedState.configuration.theme || defaultConfiguration.theme,
+      orientation: parsedState.configuration.orientation || defaultConfiguration.orientation,
     },
     code: parsedState.code,
   };

--- a/ui/frontend/reducers.js
+++ b/ui/frontend/reducers.js
@@ -7,6 +7,7 @@ export const defaultConfiguration = {
   editor: "advanced",
   keybinding: "ace",
   theme: "github",
+  orientation: "automatic",
   channel: "stable",
   mode: "debug",
   crateType: "bin",
@@ -30,6 +31,8 @@ const configuration = (state = defaultConfiguration, action) => {
     return { ...state, keybinding: action.keybinding };
   case actions.CHANGE_THEME:
     return { ...state, theme: action.theme };
+  case actions.CHANGE_ORIENTATION:
+    return { ...state, orientation: action.orientation };
   case actions.CHANGE_CHANNEL: {
     const { channel } = action;
     if (["stable", "beta", "nightly"].includes(channel)) {


### PR DESCRIPTION
As discussed in issue #162, there is now an automatic option, too. I tried to fix the the margins, but the current CSS solution is hacky and I think this should be revisited. Perhaps when adding the rotation for the hidden tab buttons in vertical split mode? I just added the split configuration for now because it has higher priority.

I'll be happy about feedback :)

### Description:

Add an option in the configuration menu to change the split behaviour
/ orientation between "Automatic" (similar to the old playground),
"Horizontal" (the current behaviour of the integer32llc playground) and
"Vertical" (similar to the old playground for widescreen displays)

### Detailed:
- Add changeOrientation and orientation to the props of Configuration
- Add a new ConfigurationSelect-instance in the Configuration
componenent
- Add said orientation state to the props of Playground
- Introduce new 'div' which contains the Editor- and the Output-divs
and has a CSS class depending on the current orientation setting
- Add a new changeOrientation-action

### CSS changes:
- Add two @mixin which are active, when during vertical split mode and
automatic split mode with a width of at least 1600px
- Add a hacky solution for margin-top of the output pane