### PR TITLE
Put the playground UI inside docker

### DIFF
--- a/.travis/build-containers.sh
+++ b/.travis/build-containers.sh
@@ -10,5 +10,6 @@ then
     docker login -u="${DOCKER_USERNAME}" -p="${DOCKER_PASSWORD}"
     export PERFORM_PUSH="true"
     # Which images to build are set via .travis.yml
-    cd compiler && ./build.sh
+    cd compiler && ./build.sh && cd ..
+    cd ui && ./build.sh && cd ..
 fi

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ cd rust-playground
 ```
 cd compiler/
 ./build.sh
-cd ../
+cd ..
 ```
 
 #### Set a crontab to rebuild the containers
@@ -151,36 +151,20 @@ crontab -e
 0 * * * * docker images -q --filter "dangling=true" | xargs docker rmi
 ```
 
-#### Build the UI backend
+#### Build the UI frontend and backend
 ```
 cd ui
-docker run -it --rm -v $PWD:/ui --workdir /ui --entrypoint /bin/bash rust-nightly
-rustup target add x86_64-unknown-linux-musl
-cargo build --target=x86_64-unknown-linux-musl --release
-# exit docker
+./build.sh
 cd ..
-```
-
-#### Build the UI frontend
-```
-cd ui/frontend
-docker run -it --rm -v $PWD:/ui --workdir /ui --entrypoint /bin/bash node
-yarn
-NODE_ENV=production yarn run build
-# exit docker
-cd ../..
 ```
 
 #### Run the server
 ```
-cd ui
-sudo \
-  TMPDIR=/mnt/playground \
-  RUST_LOG=info \
-  PLAYGROUND_UI_ADDRESS=0.0.0.0 \
-  PLAYGROUND_UI_PORT=80 \
-  PLAYGROUND_UI_ROOT=$PWD/frontend/build \
-  ./target/x86_64-unknown-linux-musl/release/ui
+docker run -it --rm \
+    --volume /var/run/docker.sock:/var/run/docker.sock \
+    --volume /mnt/playground:/mnt/playground \
+    --publish 80:80 \
+    playground
 ```
 
 ## Development
@@ -208,6 +192,7 @@ cargo run
 ```
 cd compiler
 ./build.sh
+cd ..
 ```
 
 ## License

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,0 +1,19 @@
+FROM ubuntu:16.04
+
+ENV USER=root
+ADD https://download.docker.com/linux/static/stable/x86_64/docker-17.03.0-ce.tgz /
+RUN cd /usr/bin/ && tar --strip-components=1 -xzf /docker-17.03.0-ce.tgz docker/docker
+WORKDIR /ui
+COPY ./target/x86_64-unknown-linux-musl/release/ui /ui/
+COPY frontend/build /frontend
+ENV TMPDIR=/mnt/playground \
+    RUST_LOG=info \
+    PLAYGROUND_UI_ADDRESS=0.0.0.0 \
+    PLAYGROUND_UI_PORT=80 \
+    PLAYGROUND_UI_ROOT=/frontend
+ENTRYPOINT []
+# Allow ctrl+C to work by wrapping the playground in bash
+# (it will also perform process reaping). The odd construction
+# is because if bash recognises a simple command it'll just
+# exec it directly, so add a useless additional command.
+CMD ["bash", "-c", "/ui/ui || false"]

--- a/ui/build.sh
+++ b/ui/build.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -euv -o pipefail
+
+perform_push="${PERFORM_PUSH-false}"
+
+repository=shepmaster
+
+# Build outside the image so nodejs isn't installed on the main image
+cd frontend
+docker pull node
+docker run -it --rm -v $PWD:/ui --workdir /ui --entrypoint /bin/bash node -c '
+    yarn &&
+    NODE_ENV=production yarn run build
+'
+cd ..
+
+# Also don't put a rust compiler in the main playground image
+docker run -it --rm -v $PWD:/ui --workdir /ui --entrypoint /bin/bash shepmaster/rust-nightly -c '
+    rustup target add x86_64-unknown-linux-musl &&
+    cargo build --target=x86_64-unknown-linux-musl --release
+'
+
+image_name="playground"
+full_name="${repository}/${image_name}"
+docker pull "${full_name}" || true # not on docker hub...yet
+docker build -t "${full_name}" \
+       --cache-from "${full_name}" \
+       .
+docker tag "${full_name}" "${image_name}"
+if [[ "${perform_push}" == 'true' ]]; then
+    docker push "${full_name}"
+fi


### PR DESCRIPTION
I've not yet updated the dev workflow since doing that inside docker isn't ideal (one issue is cargo redownloading packages every time).