### PR TITLE
Load code from gist.github.com with any filename

### DIFF
--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -1,1 +1,2 @@
 target
+access-log.csv

--- a/ui/frontend/gist.js
+++ b/ui/frontend/gist.js
@@ -14,11 +14,27 @@ const FILENAME = 'playground.rs';
 export function load(id) {
   return fetch(`${baseUrlStr}/${id}`)
     .then(response => response.json())
-    .then(gist => ({
-      id: id,
-      url: gist.html_url,
-      code: gist.files[FILENAME].content,
-    }));
+    .then(gist => {
+      const filenames = Object.keys(gist.files);
+      if (filenames.length > 0) {
+        let code = gist.files[filenames[0]].content;
+        if (filenames.length > 1) {
+          code = filenames.reduce(
+                            (code, filename) => `${code}\n\n// ${filename}\n\n${gist.files[filename].content}`
+                            , '')
+                            .trimLeft();
+        }
+        return {
+          id: id,
+          url: gist.html_url,
+          code: code,
+        };
+      } else {
+        alert(`No file inside gist ${baseUrlStr}/${id}`);
+        // FIXME better errorhandling
+        return {};
+      }
+    });
 }
 
 const gistBody = code => ({


### PR DESCRIPTION
Hi all

I noticed that all my gist links (eg. [this](https://play.rust-lang.org/?gist=828d338bf3cb4214a8127786d89fe085&version=stable) or [that](https://play.rust-lang.org/?gist=363d161c570fef39b555f6e08c8f7d00&version=stable&backtrace=2)) were broken because I use a more specific filename than `playground.rs`.

With this fix the UI will load the last/only file inside a gist so any name can be chosen.

Best