### PR TITLE
Use new keyword highlighting rules

### DIFF
--- a/ui/frontend/AdvancedEditor.tsx
+++ b/ui/frontend/AdvancedEditor.tsx
@@ -55,7 +55,7 @@ class AdvancedEditor extends React.PureComponent<AdvancedEditorProps> {
     return (
       <AceEditor
         ref={this.trackEditor}
-        mode="rust"
+        mode="rust-playground"
         keyboardHandler={keybinding}
         theme={theme}
         value={code}
@@ -194,7 +194,7 @@ class AdvancedEditorAsync extends React.Component<AdvancedEditorProps, AdvancedE
         this.setState({ AceEditor: AceEditor.default, ace });
 
         this.load(props);
-        const loadRustMode = import('brace/mode/rust');
+        const loadRustMode = import('./rust-playground-mode');
         const loadLanguageTools = import('brace/ext/language_tools');
         Promise.all([loadRustMode, loadLanguageTools])
           .then(() => this.setState({ modeLoading: false }));

--- a/ui/frontend/AdvancedEditor.tsx
+++ b/ui/frontend/AdvancedEditor.tsx
@@ -178,26 +178,16 @@ interface AdvancedEditorProps {
 // This also has some benefit if you choose to use the simple editor,
 // as ACE should never be loaded.
 //
-// There's some implicit ordering; the library must be loaded before
-// any other piece. Themes and keybindings can also be changed at
-// runtime.
+// Themes and keybindings can be changed at runtime.
 class AdvancedEditorAsync extends React.Component<AdvancedEditorProps, AdvancedEditorAsyncState> {
   constructor(props) {
     super(props);
     this.state = { modeLoading: true };
 
-    const loadAceEditor = import('react-ace');
-    const loadAce = import('brace');
-
-    Promise.all([loadAceEditor, loadAce])
-      .then(([AceEditor, ace]) => {
-        this.setState({ AceEditor: AceEditor.default, ace });
-
+    this.requireLibraries()
+      .then(({ default: { AceEditor, ace } }) => {
         this.load(props);
-        const loadRustMode = import('./rust-playground-mode');
-        const loadLanguageTools = import('brace/ext/language_tools');
-        Promise.all([loadRustMode, loadLanguageTools])
-          .then(() => this.setState({ modeLoading: false }));
+        this.setState({ AceEditor, ace, modeLoading: false });
       });
   }
 
@@ -230,8 +220,12 @@ class AdvancedEditorAsync extends React.Component<AdvancedEditorProps, AdvancedE
   private loadKeybinding(keybinding) {
     if (keybinding && keybinding !== this.state.keybinding) {
       this.setState({ keybindingLoading: true });
-      import('brace')
-        .then(() => import(`brace/keybinding/${keybinding}`))
+
+      this.requireLibraries()
+        .then(() => import(
+          /* webpackChunkName: "brace-keybinding-[request]" */
+          `brace/keybinding/${keybinding}`,
+        ))
         .then(() => this.setState({ keybinding, keybindingLoading: false }));
     }
   }
@@ -240,10 +234,20 @@ class AdvancedEditorAsync extends React.Component<AdvancedEditorProps, AdvancedE
     if (theme !== this.state.theme) {
       this.setState({ themeLoading: true });
 
-      import('brace')
-        .then(() => import(`brace/theme/${theme}`))
+      this.requireLibraries()
+        .then(() => import(
+          /* webpackChunkName: "brace-theme-[request]" */
+          `brace/theme/${theme}`,
+        ))
         .then(() => this.setState({ theme, themeLoading: false }));
     }
+  }
+
+  private requireLibraries() {
+    return import(
+      /* webpackChunkName: "advanced-editor" */
+      './advanced-editor',
+    );
   }
 }
 

--- a/ui/frontend/advanced-editor.ts
+++ b/ui/frontend/advanced-editor.ts
@@ -1,0 +1,10 @@
+/// React-Ace requires brace on its own and we also need it. This
+/// file will be a separate bundle and loaded async so that we only
+/// need to load brace a single time.
+
+import ace from 'brace';
+import 'brace/ext/language_tools';
+import AceEditor from 'react-ace';
+import './rust-playground-mode';
+
+export default { AceEditor, ace };

--- a/ui/frontend/rust-playground-mode.ts
+++ b/ui/frontend/rust-playground-mode.ts
@@ -1,0 +1,37 @@
+import ace from 'brace';
+import 'brace/mode/rust';
+
+ace.define('ace/mode/rust-playground', function(require, exports, module) {
+  const oop = require('ace/lib/oop');
+  const { Mode: RustMode } = require('ace/mode/rust');
+  const { RustPlaygroundHighlightRules } = require('ace/mode/rust_playground_highlight_rules');
+
+  const Mode = function() {
+    this.HighlightRules = RustPlaygroundHighlightRules;
+  };
+  oop.inherits(Mode, RustMode);
+
+  (function() {
+    // Extra logic goes here.
+  }).call(Mode.prototype);
+
+  exports.Mode = Mode;
+});
+
+ace.define('ace/mode/rust_playground_highlight_rules', function(require, exports, module) {
+  const oop = require('ace/lib/oop');
+  const { RustHighlightRules } = require('ace/mode/rust_highlight_rules');
+
+  const RustPlaygroundHighlightRules = function() {
+    this.$rules = new RustHighlightRules().getRules();
+
+    // Overriding until the next release that adds the `dyn` token
+    const rule = this.$rules.start.find(r => r.token === 'keyword.source.rust');
+    // tslint:disable-next-line max-line-length
+    rule.regex = '\\b(?:abstract|alignof|as|become|box|break|catch|continue|const|crate|default|do|dyn|else|enum|extern|for|final|if|impl|in|let|loop|macro|match|mod|move|mut|offsetof|override|priv|proc|pub|pure|ref|return|self|sizeof|static|struct|super|trait|type|typeof|union|unsafe|unsized|use|virtual|where|while|yield)\\b';
+  };
+
+  oop.inherits(RustPlaygroundHighlightRules, RustHighlightRules);
+
+  exports.RustPlaygroundHighlightRules = RustPlaygroundHighlightRules;
+});

--- a/ui/frontend/webpack.config.js
+++ b/ui/frontend/webpack.config.js
@@ -27,7 +27,7 @@ module.exports = {
     publicPath: 'assets/',
     path: `${__dirname}/build/assets`,
     filename: '[name]-[chunkhash].js',
-    chunkFilename: '[chunkhash].js',
+    chunkFilename: '[name]-[chunkhash].js',
   },
 
   resolve: {


### PR DESCRIPTION
Pleasantly, we should see a production size decrease from 340K to 249K and 4 fewer requests (w/ emacs & github), since `brace` is no longer duplicated and more async things are in one bundle.