### PR TITLE
Fix labels being removed from asm

### DIFF
--- a/ui/src/asm_cleanup.rs
+++ b/ui/src/asm_cleanup.rs
@@ -4,7 +4,7 @@ use rustc_demangle::demangle;
 
 pub fn remove_assembler_directives(block: &str) -> String {
     lazy_static! {
-        static ref ASM_DIR_REGEX: Regex = Regex::new(r"(?m)^\s*\..*$").expect("Failed to create ASM_DIR_REGEX");
+        static ref ASM_DIR_REGEX: Regex = Regex::new(r"(?m)^\s*\..*[^:]$").expect("Failed to create ASM_DIR_REGEX");
     }
 
     let mut filtered_asm = String::new();
@@ -49,8 +49,16 @@ mod test {
     #[test]
     fn many_directives_removed() {
         assert_eq!(
-            super::remove_assembler_directives(" .cfi_def_cfa_register %rbp\n subq$80, %rsp\n .Ltmp2:"),
+            super::remove_assembler_directives(" .cfi_def_cfa_register %rbp\n subq$80, %rsp\n .text\n"),
             " subq$80, %rsp\n");
+    }
+
+    #[test]
+    fn labels_not_removed() {
+        assert_eq!(
+            super::remove_assembler_directives(
+      ".type core::fmt::Arguments::new_v1,@function\n core::fmt::Arguments::new_v1:\n .Lfunc_begin0:\n"),
+             " core::fmt::Arguments::new_v1:\n .Lfunc_begin0:\n");
     }
 
     #[test]


### PR DESCRIPTION
The assembler directive screening added in 9c495af2ce660c2253e4ea97562f52559cf5a93f is removing labels as well as directives from the assembly.  As labels are needed to understand code flow, this is bad.  This change prevents labels from being removed when assembler directives are screened out. 

A future enhancement I'd like to try is to only display labels that are used, which is the default on Godbolt, but that is a more complex change and it's better to resolve this issue quickly.

**New - Labels Retained**
```asm
.LBB0_2:
	movl	$0, -48(%rbp)
	jmp	.LBB0_4    ;Target of jmp is defined
.LBB0_4:
	movq	-48(%rbp), %rax
```
**Existing - Labels Removed**
```asm
	movl	$0, -48(%rbp)
	jmp	.LBB0_4     ;No definition of .LBB0_4, unclear where jmp goes
	movq	-48(%rbp), %rax
```

