### PR TITLE
Added filter for used labels and data directives in assembly

### DIFF
--- a/ui/frontend/Configuration.tsx
+++ b/ui/frontend/Configuration.tsx
@@ -7,14 +7,14 @@ import {
   changeAssemblyFlavor,
   changeDemangleAssembly,
   changeEditor,
-  changeHideAssemblerDirectives,
   changeKeybinding,
   changeOrientation,
+  changeProcessAssembly,
   changeTheme,
   toggleConfiguration,
 } from './actions';
 import State from './state';
-import { AssemblyFlavor, DemangleAssembly, Editor, HideAssemblerDirectives, Orientation } from './types';
+import { AssemblyFlavor, DemangleAssembly, Editor, Orientation, ProcessAssembly} from './types';
 
 const keybindingOptions = ACE_KEYBINDINGS.map(t => <option value={t} key={t}>{t}</option>);
 const themeOptions = ACE_THEMES.map(t => <option value={t} key={t}>{t}</option>);
@@ -52,7 +52,7 @@ class Configuration extends React.PureComponent<ConfigurationProps> {
   private onChangeOrientation = e => this.props.changeOrientation(e.target.value);
   private onChangeAssemblyFlavor = e => this.props.changeAssemblyFlavor(e.target.value);
   private onChangeDemangleAssembly = e => this.props.changeDemangleAssembly(e.target.value);
-  private onChangeHideAssemblerDirectives = e => this.props.changeHideAssemblerDirectives(e.target.value);
+  private onChangeProcessAssembly = e => this.props.changeProcessAssembly(e.target.value);
   private onKeyup = e => {
     if (e.keyCode === ESCAPE_KEYCODE && !e.defaultPrevented) {
       e.preventDefault();
@@ -75,7 +75,7 @@ class Configuration extends React.PureComponent<ConfigurationProps> {
       orientation,
       assemblyFlavor,
       demangleAssembly,
-      hideAssemblerDirectives,
+      processAssembly,
       toggleConfiguration,
     } = this.props;
 
@@ -138,12 +138,12 @@ class Configuration extends React.PureComponent<ConfigurationProps> {
           <option value={DemangleAssembly.Mangle}>Mangled</option>
         </ConfigurationSelect>
 
-        <ConfigurationSelect what="hideAssemblerDirectives"
-                             label="Assembler Directives"
-                             defaultValue={hideAssemblerDirectives}
-                             onChange={this.onChangeHideAssemblerDirectives}>
-          <option value={HideAssemblerDirectives.Hide}>Remove</option>
-          <option value={HideAssemblerDirectives.Show}>Display</option>
+        <ConfigurationSelect what="processAssembly"
+                             label="Assembly View"
+                             defaultValue={processAssembly}
+                             onChange={this.onChangeProcessAssembly}>
+          <option value={ProcessAssembly.Filter}>Filtered</option>
+          <option value={ProcessAssembly.Raw}>Raw</option>
         </ConfigurationSelect>
 
         <div className="configuration-actions">
@@ -161,14 +161,14 @@ interface ConfigurationProps {
   changeOrientation: (Orientation) => any;
   changeAssemblyFlavor: (AssemblyFlavor) => any;
   changeDemangleAssembly: (DemangleAssembly) => any;
-  changeHideAssemblerDirectives: (HideAssemblerDirectives) => any;
+  changeProcessAssembly: (ProcessAssembly) => any;
   editor: Editor;
   keybinding: string;
   theme: string;
   orientation: Orientation;
   assemblyFlavor: AssemblyFlavor;
   demangleAssembly: DemangleAssembly;
-  hideAssemblerDirectives: HideAssemblerDirectives;
+  processAssembly: ProcessAssembly;
   toggleConfiguration: () => any;
 }
 
@@ -179,7 +179,7 @@ const mapStateToProps = ({ configuration: {
   orientation,
   assemblyFlavor,
   demangleAssembly,
-  hideAssemblerDirectives},
+  processAssembly},
 }: State) => (
   {
     editor,
@@ -188,7 +188,7 @@ const mapStateToProps = ({ configuration: {
     orientation,
     assemblyFlavor,
     demangleAssembly,
-    hideAssemblerDirectives,
+    processAssembly,
   }
 );
 
@@ -199,7 +199,7 @@ const mapDispatchToProps = ({
   changeOrientation,
   changeAssemblyFlavor,
   changeDemangleAssembly,
-  changeHideAssemblerDirectives,
+  changeProcessAssembly,
   toggleConfiguration,
 });
 

--- a/ui/frontend/actions.ts
+++ b/ui/frontend/actions.ts
@@ -10,10 +10,10 @@ import {
   Channel,
   DemangleAssembly,
   Editor,
-  HideAssemblerDirectives,
   Mode,
   Orientation,
   Page,
+  ProcessAssembly,
 } from './types';
 
 const routes = {
@@ -55,7 +55,7 @@ export enum ActionType {
   ChangeAssemblyFlavor = 'CHANGE_ASSEMBLY_FLAVOR',
   ChangeChannel = 'CHANGE_CHANNEL',
   ChangeDemangleAssembly = 'CHANGE_DEMANGLE_ASSEMBLY',
-  ChangeHideAssemblerDirectives = 'CHANGE_HIDE_ASSEMBLER_DIRECTIVES',
+  ChangeProcessAssembly = 'CHANGE_PROCESS_ASSEMBLY',
   ChangeMode = 'CHANGE_MODE',
   ChangeFocus = 'CHANGE_FOCUS',
   ExecuteRequest = 'EXECUTE_REQUEST',
@@ -85,7 +85,7 @@ export type Action =
   | ChangeDemangleAssemblyAction
   | ChangeEditorAction
   | ChangeFocusAction
-  | ChangeHideAssemblerDirectivesAction
+  | ChangeProcessAssemblyAction
   | ChangeKeybindingAction
   | ChangeModeAction
   | ChangeOrientationAction
@@ -148,9 +148,9 @@ export interface ChangeDemangleAssemblyAction {
   demangleAssembly: DemangleAssembly;
 }
 
-export interface ChangeHideAssemblerDirectivesAction {
-  type: ActionType.ChangeHideAssemblerDirectives;
-  hideAssemblerDirectives: HideAssemblerDirectives;
+export interface ChangeProcessAssemblyAction {
+  type: ActionType.ChangeProcessAssembly;
+  processAssembly: ProcessAssembly;
 }
 
 export interface ChangeChannelAction {
@@ -196,8 +196,8 @@ export function changeDemangleAssembly(demangleAssembly): ChangeDemangleAssembly
   return { type: ActionType.ChangeDemangleAssembly, demangleAssembly };
 }
 
-export function changeHideAssemblerDirectives(hideAssemblerDirectives): ChangeHideAssemblerDirectivesAction {
-  return { type: ActionType.ChangeHideAssemblerDirectives, hideAssemblerDirectives };
+export function changeProcessAssembly(processAssembly): ChangeProcessAssemblyAction {
+  return { type: ActionType.ChangeProcessAssembly, processAssembly };
 }
 
 export function changeChannel(channel: Channel): ChangeChannelAction {
@@ -302,7 +302,7 @@ function performCompile(target, { request, success, failure }): ThunkAction {
       mode,
       assemblyFlavor,
       demangleAssembly,
-      hideAssemblerDirectives,
+      processAssembly,
     } } = state;
     const crateType = getCrateType(state);
     const tests = runAsTest(state);
@@ -315,7 +315,7 @@ function performCompile(target, { request, success, failure }): ThunkAction {
       target,
       assemblyFlavor,
       demangleAssembly,
-      hideAssemblerDirectives,
+      processAssembly,
     };
 
     return jsonPost(routes.compile, body)

--- a/ui/frontend/local_storage.ts
+++ b/ui/frontend/local_storage.ts
@@ -11,7 +11,7 @@ export function serialize(state) {
       orientation: state.configuration.orientation,
       assemblyFlavor: state.configuration.assemblyFlavor,
       demangleAssembly: state.configuration.demangleAssembly,
-      hideAssemblerDirectives: state.configuration.hideAssemblerDirectives,
+      processAssembly: state.configuration.processAssembly,
     },
     code: state.code,
   });
@@ -31,8 +31,7 @@ export function deserialize(savedState) {
       orientation: parsedState.configuration.orientation || defaultConfiguration.orientation,
       assemblyFlavor: parsedState.configuration.assemblyFlavor || defaultConfiguration.assemblyFlavor,
       demangleAssembly: parsedState.configuration.demangleAssembly || defaultConfiguration.demangleAssembly,
-      hideAssemblerDirectives:
-        parsedState.configuration.hideAssemblerDirectives || defaultConfiguration.hideAssemblerDirectives,
+      processAssembly: parsedState.configuration.processAssembly || defaultConfiguration.processAssembly,
     },
     code: parsedState.code,
   };

--- a/ui/frontend/reducers/configuration.ts
+++ b/ui/frontend/reducers/configuration.ts
@@ -4,9 +4,9 @@ import {
   Channel,
   DemangleAssembly,
   Editor,
-  HideAssemblerDirectives,
   Mode,
   Orientation,
+  ProcessAssembly,
 } from '../types';
 
 export interface State {
@@ -17,7 +17,7 @@ export interface State {
   orientation: Orientation;
   assemblyFlavor: AssemblyFlavor;
   demangleAssembly: DemangleAssembly;
-  hideAssemblerDirectives: HideAssemblerDirectives;
+  processAssembly: ProcessAssembly;
   channel: Channel;
   mode: Mode;
 }
@@ -30,7 +30,7 @@ export const DEFAULT: State = {
   orientation: Orientation.Automatic,
   assemblyFlavor: AssemblyFlavor.Att,
   demangleAssembly: DemangleAssembly.Demangle,
-  hideAssemblerDirectives: HideAssemblerDirectives.Hide,
+  processAssembly: ProcessAssembly.Filter,
   channel: Channel.Stable,
   mode: Mode.Debug,
 };
@@ -51,8 +51,8 @@ export default function configuration(state = DEFAULT, action: Action): State {
     return { ...state, assemblyFlavor: action.assemblyFlavor };
   case ActionType.ChangeDemangleAssembly:
     return { ...state, demangleAssembly: action.demangleAssembly };
-  case ActionType.ChangeHideAssemblerDirectives:
-    return { ...state, hideAssemblerDirectives: action.hideAssemblerDirectives };
+  case ActionType.ChangeProcessAssembly:
+    return { ...state, processAssembly: action.processAssembly };
   case ActionType.ChangeChannel:
     return { ...state, channel: action.channel };
   case ActionType.ChangeMode:

--- a/ui/frontend/types.ts
+++ b/ui/frontend/types.ts
@@ -46,9 +46,9 @@ export enum DemangleAssembly {
   Mangle = 'mangle',
 }
 
-export enum HideAssemblerDirectives {
-  Hide = 'hide',
-  Show = 'show',
+export enum ProcessAssembly {
+  Filter = 'filter',
+  Raw = 'raw',
 }
 
 export enum Channel {

--- a/ui/src/asm_cleanup.rs
+++ b/ui/src/asm_cleanup.rs
@@ -1,73 +1,139 @@
+// Thanks to Matt Godbolt for creating the amazing Compiler Explorer https://www.godbolt.org
+// This aims to provide similar assembly cleanup to what Godbolt does
+
 use regex::Regex;
 use regex::Captures;
 use rustc_demangle::demangle;
+use std::collections::HashSet;
 
-pub fn remove_assembler_directives(block: &str) -> String {
+pub fn demangle_asm(block: &str) -> String {
     lazy_static! {
-        static ref ASM_DIR_REGEX: Regex = Regex::new(r"(?m)^\s*\..*[^:]$").expect("Failed to create ASM_DIR_REGEX");
+        static ref DEMANGLE_REGEX: Regex = Regex::new(r"_[a-zA-Z0-9._$]*").unwrap();
     }
 
-    let mut filtered_asm = String::new();
+    DEMANGLE_REGEX.replace_all(block, |caps: &Captures| {
+        format!("{:#}", demangle(caps.get(0).map_or("", |m| m.as_str())))
+    }).to_string()
+}
+
+enum LineType<'a> {
+    Opcode,
+    LabelDecl(&'a str),
+    Data(&'a str),
+    FunctionDecl,
+    Directive,
+    Blank,
+    Misc,
+}
+
+// Removes unused labels and directives from assembly
+pub fn filter_asm(block: &str) -> String {
+
+    use self::LineType::*;
+
+    lazy_static! {
+        // Example:    mov rax, rdx
+        // Always inlude in results
+        static ref OPCODE_REGEX: Regex = Regex::new(r"^\s*[a-zA-Z]+.*[^:]$").unwrap();
+    }
+    lazy_static! {
+        // Example:.Lfunc_end7:
+        // Finds label declarations
+        // Include in results only if it is referenced by an opcode, or is a function
+        static ref LABEL_DECL_REGEX: Regex = Regex::new(r"([a-zA-Z_.<][a-zA-Z0-9$&_.<>\[\]{}:' ]*):$").unwrap();
+    }
+    lazy_static! {
+        // Example:    mov lea rdi, [rip + str.0] // str.0 is the referenced label
+        // Find labels used as operands for an opcode
+        static ref LABEL_REF_REGEX: Regex = Regex::new(r"([a-zA-Z_.][a-zA-Z0-9$_.]*)").unwrap();
+    }
+    lazy_static! {
+        // Example:    .string "Hello, world!"
+        // Note: this is a type of directive
+        // Include in results if it is part of a used label, may contain label references
+        static ref DATA_REGEX: Regex = Regex::new(r"^\s*\.(string|asciz|ascii|[1248]?byte|short|word|long|quad|value|zero)").unwrap();
+    }
+    lazy_static! {
+        // Example:    .type main,@function
+        // Note: this is a type of directive
+        // Never include in results, but is used to find and include functions
+        static ref FUNCTION_REGEX: Regex = Regex::new(r"^\s*\.type\s*(.*),@function$").unwrap();
+    }
+    lazy_static! {
+        // Example:    .p2align 4, 0x90
+        // Note: this will also match entries found by DATA_REGEX and FUNCTION_REGEX
+        // Never include in results
+        static ref DIRECTIVE_REGEX: Regex = Regex::new(r"^\s*\..*[^:]$").unwrap();
+    }
+    lazy_static! {
+        // Never include in results
+        static ref BLANK_REGEX: Regex = Regex::new(r"^\s*$").unwrap();
+    }
+
+    let mut current_label: &str = "";
+    let mut line_info: Vec<LineType> = Vec::new();
+    let mut labels: HashSet<&str> = HashSet::new();
+    let mut opcode_operands: HashSet<&str> = HashSet::new();
+
+    // Note the type of data held on each line of the block
     for line in block.lines() {
-        if !ASM_DIR_REGEX.is_match(line) {
-            filtered_asm.push_str(line);
-            filtered_asm.push('\n');
+        if OPCODE_REGEX.is_match(line) {
+            line_info.push(Opcode);
+            // Skip the opcode, just add operands
+            for label_ref_cap in LABEL_REF_REGEX.captures_iter(line).skip(1).filter_map(|cap| cap.get(1)) {
+                opcode_operands.insert(label_ref_cap.as_str());
+            }
+        } else if let Some(label_decl_cap) = LABEL_DECL_REGEX.captures(line).map_or(None, |cap| cap.get(1)) {
+            line_info.push(LabelDecl(label_decl_cap.as_str()));
+            labels.insert(label_decl_cap.as_str());
+            current_label = label_decl_cap.as_str(); 
+        } else if DATA_REGEX.is_match(line) && current_label != "" { 
+            line_info.push(Data(current_label));
+            // Skip the data directive, just add operands
+            for label_ref_cap in LABEL_REF_REGEX.captures_iter(line).skip(1).filter_map(|cap| cap.get(1)) {
+                opcode_operands.insert(label_ref_cap.as_str());
+            }
+        } else if let Some(function_cap) = FUNCTION_REGEX.captures(line).map_or(None, |cap| cap.get(1)) { 
+            line_info.push(FunctionDecl); 
+            opcode_operands.insert(function_cap.as_str());
+        // DIRECTIVE_REGEX must be checked after FUNCTION_REGEX and DATA_REGEX, matches them too
+        } else if DIRECTIVE_REGEX.is_match(line) { 
+            line_info.push(Directive);
+        } else if BLANK_REGEX.is_match(line) {
+            line_info.push(Blank);
+        // If no matches are found then include line in output
+        } else {
+            line_info.push(Misc); 
+        }
+    }
+
+    let used_labels: HashSet<_> = labels.intersection(&opcode_operands).collect();
+
+    let mut filtered_asm = String::new();
+    for (line, line_type) in block.lines().zip(&line_info) {
+        match line_type {
+            &Opcode | &Misc => { 
+                filtered_asm.push_str(line);
+                filtered_asm.push('\n');
+            },
+            &Data(ref data) if used_labels.contains(data) => { 
+                filtered_asm.push_str(line);
+                filtered_asm.push('\n');
+            },
+            &LabelDecl(ref label) if used_labels.contains(label) => {
+                filtered_asm.push('\n');
+                filtered_asm.push_str(line);
+                filtered_asm.push('\n');
+            },
+            _ => (),
         }
     }
 
     filtered_asm
 }
 
-pub fn demangle_asm(block: &str) -> String {
-    lazy_static! {
-        static ref DEMANGLE_REGEX: Regex = Regex::new(r"_[a-zA-Z0-9._$]*").expect("Failed to create DEMANGLE_REGEX");
-    }
-
-    DEMANGLE_REGEX.replace_all(block, |caps: &Captures| {
-        format!("{:#}", demangle(caps.get(0)
-                                     .expect("Failed to find symbols to demangle")
-                                     .as_str()))
-    }).to_string()
-}
-
 #[cfg(test)]
 mod test {
-    #[test]
-    fn directives_pass_through() {
-        assert_eq!(
-            super::remove_assembler_directives("core::fmt::Arguments::new_v1:\n push rbp\n mov rbp, rsp"),
-            "core::fmt::Arguments::new_v1:\n push rbp\n mov rbp, rsp\n");
-    }
-
-    #[test]
-    fn one_directive_removed() {
-        assert_eq!(
-            super::remove_assembler_directives("  .filesystem1 \"<println macros>\"\n  movq%rsp, %rbp\n"),
-            "  movq%rsp, %rbp\n");
-    }
-
-    #[test]
-    fn many_directives_removed() {
-        assert_eq!(
-            super::remove_assembler_directives(" .cfi_def_cfa_register %rbp\n subq$80, %rsp\n .text\n"),
-            " subq$80, %rsp\n");
-    }
-
-    #[test]
-    fn labels_not_removed() {
-        assert_eq!(
-            super::remove_assembler_directives(
-      ".type core::fmt::Arguments::new_v1,@function\n core::fmt::Arguments::new_v1:\n .Lfunc_begin0:\n"),
-             " core::fmt::Arguments::new_v1:\n .Lfunc_begin0:\n");
-    }
-
-    #[test]
-    fn demangle_pass_through() {
-        assert_eq!(
-            super::demangle_asm("push rbp\n mov rbp, rsp"),
-            "push rbp\n mov rbp, rsp");
-    }
-
     #[test]
     fn demangles() {
         assert_eq!(
@@ -81,5 +147,64 @@ mod test {
             super::demangle_asm(".section.text._ZN4core3fmt9Arguments6new_v117h3c6f806acbe1ddabE,\"ax\",@progbits\n .p2align4, 0x90\n .type_ZN4core3fmt9Arguments6new_v117h3c6f806acbe1ddabE,@function"),
             ".section.text.core::fmt::Arguments::new_v1,\"ax\",@progbits\n .p2align4, 0x90\n .typecore::fmt::Arguments::new_v1,@function");
         }
-    
+
+    #[test]
+    fn demangle_pass_through() {
+        assert_eq!(
+            super::demangle_asm("push rbp\n mov rbp, rsp"),
+            "push rbp\n mov rbp, rsp");
+    }
+
+    #[test]
+    fn one_directive_removed() {
+        assert_eq!(
+            super::filter_asm("  .filesystem1 \"<println macros>\"\n  movq%rsp, %rbp\n"),
+            "  movq%rsp, %rbp\n");
+    }
+
+    #[test]
+    fn many_directives_removed() {
+        assert_eq!(
+            super::filter_asm(" .cfi_def_cfa_register %rbp\n subq$80, %rsp\n .text\n"),
+            " subq$80, %rsp\n");
+    }
+
+    #[test]
+    fn used_label_kept() {
+        assert_eq!(
+            
+            super::filter_asm(".Lcfi0:\ncallq    .Lcfi0\n"),
+            "\n.Lcfi0:\ncallq    .Lcfi0\n");
+    }
+
+    #[test]
+    fn unused_label_removed() {
+        assert_eq!(
+        super::filter_asm("addq    $16, %rsp\n    popq    %rbp\n    retq\n.Lfunc_end31:\nstr.0:\n"),
+        "addq    $16, %rsp\n    popq    %rbp\n    retq\n");
+    }
+
+    #[test]
+    fn used_data_kept() {
+        assert_eq!(super::filter_asm("ref.2:\n  .quad 1\n  jmp ref.2\n"),
+        "\nref.2:\n  .quad 1\n  jmp ref.2\n")
+    }
+
+    #[test]
+    fn unused_data_removed() {
+        assert_eq!(super::filter_asm("str.0:\n  .ascii \"Hello, world\"\n  pop rbp\n"),
+        "  pop rbp\n");
+    }
+
+    #[test]
+    fn blank_lines_removed() {
+        assert_eq!(super::filter_asm("  mov rbp, rsp\n  main:\n  jmp core::fmt::Arguments\n  \n"),
+        "  mov rbp, rsp\n  jmp core::fmt::Arguments\n")
+    }
+
+    #[test]
+    fn functions_kept() {
+        assert_eq!(super::filter_asm("  .type main,@function\n  main:\n  pushq %rax\n"),
+        "\n  main:\n  pushq %rax\n");
+    }
 }


### PR DESCRIPTION
This adds more thorough filtering and formatting to the assembly view, removing unused labels and keeping relevant data directives.

The "Assembler Directives" option in the Configuration menu is renamed to a more generic "Assembly View," as more than just directives are being removed now.  Internally, "hideAssemblerDirectives" is changed to "processAssembly" for the same reason.

**New**
```asm
playground::main:
	subq	$56, %rsp
	leaq	ref.2(%rip), %rax
	movq	%rax, 8(%rsp)

str.1:
	.ascii	"Hello, world!\n"

ref.2:
	.quad	str.1
	.quad	14
```

**Current**
```asm
playground::main:
	subq	$56, %rsp
.Lcfi0:
	leaq	ref.2(%rip), %rax
	movq	%rax, 8(%rsp)
.Lfunc_end1:

str.1:

ref.2:
```