### PR TITLE
Disable incremental compilation to resolve issue 252

### DIFF
--- a/top-crates/src/main.rs
+++ b/top-crates/src/main.rs
@@ -77,6 +77,7 @@ struct Modifications {
 #[serde(rename_all="kebab-case")]
 struct Profile {
     codegen_units: u32,
+    incremental: bool,
 }
 
 /// Available profile types
@@ -253,8 +254,8 @@ fn main() {
             authors: vec!["The Rust Playground".to_owned()],
         },
         profile: Profiles {
-            dev: Profile { codegen_units: 1 },
-            release: Profile { codegen_units: 1 },
+            dev: Profile { codegen_units: 1, incremental: false },
+            release: Profile { codegen_units: 1, incremental: false },
         },
         dependencies: unique_latest_crates.clone(),
     };


### PR DESCRIPTION
Apologies for the onslaught of pull requests lately, but this one should resolve the underlying problem from #252.

I found that incremental compilation will disregard the value of codegen-units, causing multiple output files to be created when using -o foo --emit=bar.  This was why the issue only occurred in nightly and beta debug, stable rustc and release builds do not use incremental compilation.

I opened rust-lang/rust#48147 to rustc, but we can mitigate the issue for the playground immediately by disabling incremental compilation via Cargo.toml.