### PR TITLE
Add "Compiler Options" input field to Playground header

### DIFF
--- a/ui/frontend/Header.tsx
+++ b/ui/frontend/Header.tsx
@@ -5,6 +5,7 @@ import Link from './uss-router/Link';
 import {
   changeChannel,
   changeMode,
+  editCompilerFlags,
   navigateToHelp,
   performClippy,
   performCompileToAssembly,
@@ -67,6 +68,8 @@ const executionLabel = (crateType, tests) => {
 };
 
 class Header extends React.PureComponent<HeaderProps> {
+  private onChange = e => this.props.onEditCompilerFlags(e.target.value);
+
   public render() {
     const {
       execute, compileToAssembly, compileToLLVM, compileToMir, compileToWasm,
@@ -75,7 +78,7 @@ class Header extends React.PureComponent<HeaderProps> {
       crateType, tests,
       toggleConfiguration, navigateToHelp,
       stableVersion, betaVersion, nightlyVersion,
-      wasmAvailable,
+      wasmAvailable, compilerFlags, onEditCompilerFlags,
     } = this.props;
 
     const oneChannel = (value: Channel, labelText, extras) =>
@@ -138,6 +141,16 @@ class Header extends React.PureComponent<HeaderProps> {
           </div>
         </div>
 
+        <div className="header-flags header-set">
+          <legend className="header-set__title">Compiler Options</legend>
+          <div className="editor">
+            <input
+              value={this.props.compilerFlags}
+              onChange={this.onChange}
+              placeholder="-C or -Z"/>
+          </div>
+         </div>
+
         <div className="header-set">
           <div className="header-set__buttons">
             <button className="header-set__btn"
@@ -164,6 +177,8 @@ interface HeaderProps {
   compileToLLVM: () => any;
   compileToMir: () => any;
   compileToWasm: () => any;
+  compilerFlags: string;
+  onEditCompilerFlags: (_: string) => any;
   execute: () => any;
   format: () => any;
   gistSave: () => any;
@@ -179,9 +194,10 @@ interface HeaderProps {
 }
 
 const mapStateToProps = (state: State) => {
-  const { configuration: { channel, mode } } = state;
+  const { compilerFlags, configuration: { channel, mode } } = state;
 
   return {
+    compilerFlags,
     channel,
     mode,
     crateType: getCrateType(state),
@@ -205,6 +221,7 @@ const mapDispatchToProps = ({
   execute: performExecute,
   format: performFormat,
   gistSave: performGistSave,
+  onEditCompilerFlags: editCompilerFlags,
   toggleConfiguration,
 });
 

--- a/ui/frontend/actions.ts
+++ b/ui/frontend/actions.ts
@@ -3,7 +3,7 @@ import { ThunkAction as ReduxThunkAction } from 'redux-thunk';
 import url from 'url';
 
 import { load as loadGist, save as saveGist } from './gist';
-import { getCrateType, runAsTest } from './selectors';
+import { getCompilerFlags, getCrateType, runAsTest } from './selectors';
 import State from './state';
 import {
   AssemblyFlavor,
@@ -304,6 +304,7 @@ function performCompile(target, { request, success, failure }): ThunkAction {
       demangleAssembly,
       processAssembly,
     } } = state;
+    const compilerFlags = getCompilerFlags(state);
     const crateType = getCrateType(state);
     const tests = runAsTest(state);
     const body = {
@@ -312,6 +313,7 @@ function performCompile(target, { request, success, failure }): ThunkAction {
       crateType,
       tests,
       code,
+      compilerFlags,
       target,
       assemblyFlavor,
       demangleAssembly,
@@ -449,6 +451,12 @@ export const GOTO_POSITION = 'GOTO_POSITION';
 
 export function editCode(code) {
   return { type: EDIT_CODE, code };
+}
+
+export const EDIT_COMPILER_FLAGS = 'EDIT_COMPILER_FLAGS';
+
+export function editCompilerFlags(compilerFlags) {
+  return { type: EDIT_COMPILER_FLAGS, compilerFlags };
 }
 
 export function gotoPosition(line, column) {

--- a/ui/frontend/reducers/compilerFlags.ts
+++ b/ui/frontend/reducers/compilerFlags.ts
@@ -1,0 +1,14 @@
+import * as actions from '../actions';
+
+const DEFAULT: State = '';
+
+export type State = string;
+
+export default function compilerFlags(state = DEFAULT, action) {
+  switch (action.type) {
+  case actions.EDIT_COMPILER_FLAGS:
+    return action.compilerFlags;
+  default:
+    return state;
+  }
+}

--- a/ui/frontend/reducers/index.ts
+++ b/ui/frontend/reducers/index.ts
@@ -1,6 +1,7 @@
 import { combineReducers } from 'redux';
 
 import code, { State as CodeState } from './code';
+import compilerFlags, { State as CompilerFlagsState } from './compilerFlags';
 import configuration, { State as ConfigurationState } from './configuration';
 import crates, { State as CratesState } from './crates';
 import output, { State as OutputState } from './output';
@@ -9,6 +10,7 @@ import position, { State as PositionState } from './position';
 import versions, { State as VersionsState } from './versions';
 
 export interface State {
+  compilerFlags: CompilerFlagsState;
   configuration: ConfigurationState;
   code: CodeState;
   crates: CratesState;
@@ -19,6 +21,7 @@ export interface State {
 }
 
 const playgroundApp = combineReducers({
+  compilerFlags,
   configuration,
   code,
   crates,

--- a/ui/frontend/selectors/index.ts
+++ b/ui/frontend/selectors/index.ts
@@ -13,6 +13,8 @@ const CRATE_TYPE_RE = /^\s*#!\s*\[\s*crate_type\s*=\s*"([^"]*)"\s*]/m;
 const getCrateTypeRaw = code => (code.match(CRATE_TYPE_RE) || [null, 'bin'])[1];
 export const getCrateType = createSelector([getCode], getCrateTypeRaw);
 
+export const getCompilerFlags = state => state.compilerFlags;
+
 const getStable = (state: State) => state.versions && state.versions.stable;
 const getBeta = (state: State) => state.versions && state.versions.beta;
 const getNightly = (state: State) => state.versions && state.versions.nightly;


### PR DESCRIPTION
This request creates an input field titled "Compiler Options" in the header section of the playground, allowing users to enter one or more -C or -Z rustc flags.  The options requested in #260 and #211 can be enabled using the new field.

![image](https://user-images.githubusercontent.com/10663805/37132806-c45f6814-225d-11e8-99a0-df639645b4e2.png)

To mitigate the risk of passing user input to the command line, the flags are run through a regex that disregards any entries not in the expected format of ```-C/-Z flag=val```.  This could be confusing for someone unknowingly using an incorrect format, as invalid entries are silently ignored.

Flags are only passed on compile requests.