### PR TITLE
Prebuild Clippy build artifacts

### DIFF
--- a/compiler/clippy/Dockerfile
+++ b/compiler/clippy/Dockerfile
@@ -3,3 +3,10 @@ FROM shepmaster/rust-nightly
 ARG version
 
 RUN cargo install clippy --vers "${version}"
+
+# TODO: Now that Clippy uses `cargo check`, we don't need to build on
+# top of the nightly image with pre-built crates. Evaluate if it's
+# worth it to split up the builds.
+RUN echo 'fn main() {}' > src/main.rs && \
+    cargo clippy && \
+    rm src/main.rs


### PR DESCRIPTION
Now that Clippy uses `cargo check`, we can't rely on the existing
build artifacts from our base container.