### PR TITLE
Added PLAYGROUND_GITHUB_TOKEN to Build and run the server instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ basic HTML/CSS/JS changes, directly open in your browser the built
 cd ui
 RUST_LOG=ui=debug \
 PLAYGROUND_UI_ROOT=$PWD/frontend/build/ \
+PLAYGROUND_GITHUB_TOKEN=YOUR_TOKEN \
 cargo run
 ```
 


### PR DESCRIPTION
This updates the "Build and run the server" section of the readme to include the new required environment variable PLAYGROUND_GITHUB_TOKEN .