### PR TITLE
presentation mode

### DIFF
--- a/ui/frontend/Configuration.tsx
+++ b/ui/frontend/Configuration.tsx
@@ -9,12 +9,13 @@ import {
   changeEditor,
   changeKeybinding,
   changeOrientation,
+  changePageMode,
   changeProcessAssembly,
   changeTheme,
   toggleConfiguration,
 } from './actions';
 import State from './state';
-import { AssemblyFlavor, DemangleAssembly, Editor, Orientation, ProcessAssembly} from './types';
+import {AssemblyFlavor, DemangleAssembly, Editor, Orientation, PageMode, ProcessAssembly} from './types';
 
 const keybindingOptions = ACE_KEYBINDINGS.map(t => <option value={t} key={t}>{t}</option>);
 const themeOptions = ACE_THEMES.map(t => <option value={t} key={t}>{t}</option>);
@@ -47,6 +48,7 @@ const ESCAPE_KEYCODE = 27;
 
 class Configuration extends React.PureComponent<ConfigurationProps> {
   private onChangeEditor = e => this.props.changeEditor(e.target.value);
+  private onChangePageMode = e => this.props.changePageMode(e.target.value);
   private onChangeKeybinding = e => this.props.changeKeybinding(e.target.value);
   private onChangeTheme = e => this.props.changeTheme(e.target.value);
   private onChangeOrientation = e => this.props.changeOrientation(e.target.value);
@@ -70,6 +72,7 @@ class Configuration extends React.PureComponent<ConfigurationProps> {
 
   public render() {
     const { editor,
+      pageMode,
       keybinding,
       theme,
       orientation,
@@ -101,6 +104,14 @@ class Configuration extends React.PureComponent<ConfigurationProps> {
 
     return (
       <div className="configuration">
+        <ConfigurationSelect what="pageMode"
+                               label="Page Mode"
+                               defaultValue={pageMode}
+                               onChange={this.onChangePageMode}>
+          <option value={PageMode.Normal}>Normal</option>
+          <option value={PageMode.Presentation}>Presentation</option>
+        </ConfigurationSelect>
+
         <ConfigurationSelect what="editor"
                              label="Editor Style"
                              defaultValue={editor}
@@ -156,6 +167,7 @@ class Configuration extends React.PureComponent<ConfigurationProps> {
 
 interface ConfigurationProps {
   changeEditor: (Editor) => any;
+  changePageMode: (PageMode) => any;
   changeKeybinding: (_: string) => any;
   changeTheme: (_: string) => any;
   changeOrientation: (Orientation) => any;
@@ -163,6 +175,7 @@ interface ConfigurationProps {
   changeDemangleAssembly: (DemangleAssembly) => any;
   changeProcessAssembly: (ProcessAssembly) => any;
   editor: Editor;
+  pageMode: PageMode;
   keybinding: string;
   theme: string;
   orientation: Orientation;
@@ -174,6 +187,7 @@ interface ConfigurationProps {
 
 const mapStateToProps = ({ configuration: {
   editor,
+  pageMode,
   keybinding,
   theme,
   orientation,
@@ -183,6 +197,7 @@ const mapStateToProps = ({ configuration: {
 }: State) => (
   {
     editor,
+    pageMode,
     keybinding,
     theme,
     orientation,
@@ -194,6 +209,7 @@ const mapStateToProps = ({ configuration: {
 
 const mapDispatchToProps = ({
   changeEditor,
+  changePageMode,
   changeKeybinding,
   changeTheme,
   changeOrientation,

--- a/ui/frontend/Header.tsx
+++ b/ui/frontend/Header.tsx
@@ -25,7 +25,7 @@ import {
   stableVersionText,
 } from './selectors';
 import State from './state';
-import { Channel, Mode } from './types';
+import { Channel, Mode, PageMode } from './types';
 
 function oneRadio<T>(
   name: string,
@@ -71,7 +71,7 @@ class Header extends React.PureComponent<HeaderProps> {
     const {
       execute, compileToAssembly, compileToLLVM, compileToMir, compileToWasm,
       format, clippy, gistSave,
-      channel, changeChannel, mode, changeMode,
+      channel, changeChannel, mode, changeMode, pageMode,
       crateType, tests,
       toggleConfiguration, navigateToHelp,
       stableVersion, betaVersion, nightlyVersion,
@@ -84,6 +84,15 @@ class Header extends React.PureComponent<HeaderProps> {
       oneRadio('mode', mode, value, changeMode, labelText);
 
     const primaryLabel = executionLabel(crateType, tests);
+
+
+      const share = pageMode === PageMode.Presentation ? '' : <div className="header-sharing header-set">
+        <div className="header-set__buttons">
+          <button className="header-set__btn"
+            onClick={gistSave}>Share</button>
+          </div>
+        </div>;
+
 
     return (
       <div className="header">
@@ -108,40 +117,35 @@ class Header extends React.PureComponent<HeaderProps> {
           <legend className="header-set__title">Tools</legend>
           <div className="header-set__buttons">
             <button className="header-set__btn"
-              onClick={format}>Format</button>
+              onClick={format}>{pageMode === PageMode.Presentation ? 'F' : 'Format'}</button>
             <button className="header-set__btn"
-              onClick={clippy}>Clippy</button>
+              onClick={clippy}>{pageMode === PageMode.Presentation ? 'C' : 'Format'}</button>
           </div>
         </div>
 
-        <div className="header-sharing header-set">
-          <div className="header-set__buttons">
-            <button className="header-set__btn"
-              onClick={gistSave}>Share</button>
-          </div>
-        </div>
+        {share}
 
         <div className="header-mode header-set">
           <legend className="header-set__title">Mode</legend>
           <div className="header-set__buttons header-set__buttons--radio">
-            {oneMode(Mode.Debug, 'Debug')}
-            {oneMode(Mode.Release, 'Release')}
+            {oneMode(Mode.Debug, pageMode === PageMode.Presentation ? 'D' : 'Debug')}
+            {oneMode(Mode.Release, pageMode === PageMode.Presentation ? 'R' : 'Release')}
           </div>
         </div>
 
         <div className="header-channel header-set">
           <legend className="header-set__title">Channel</legend>
           <div className="header-set__buttons header-set__buttons--radio">
-            {oneChannel(Channel.Stable, 'Stable', { title: stableVersion })}
-            {oneChannel(Channel.Beta, 'Beta', { title: betaVersion })}
-            {oneChannel(Channel.Nightly, 'Nightly', { title: nightlyVersion })}
+            {oneChannel(Channel.Stable, pageMode === PageMode.Presentation ? 'S' : 'Stable', { title: stableVersion })}
+            {oneChannel(Channel.Beta, pageMode === PageMode.Presentation ? 'B' : 'Beta', { title: betaVersion })}
+            {oneChannel(Channel.Nightly, pageMode === PageMode.Presentation ? 'N' : 'Nightly', { title: nightlyVersion })}
           </div>
         </div>
 
         <div className="header-set">
           <div className="header-set__buttons">
             <button className="header-set__btn"
-              onClick={toggleConfiguration}>Config</button>
+              onClick={toggleConfiguration}>{pageMode === PageMode.Presentation ? 'C' : 'Config'}</button>
           </div>
         </div>
 
@@ -168,6 +172,7 @@ interface HeaderProps {
   format: () => any;
   gistSave: () => any;
   mode: Mode;
+  pageMode: PageMode;
   crateType: string;
   tests: boolean;
   toggleConfiguration: () => any;
@@ -179,11 +184,12 @@ interface HeaderProps {
 }
 
 const mapStateToProps = (state: State) => {
-  const { configuration: { channel, mode } } = state;
+  const { configuration: { channel, mode, pageMode } } = state;
 
   return {
     channel,
     mode,
+    pageMode,
     crateType: getCrateType(state),
     tests: runAsTest(state),
     navigateToHelp,

--- a/ui/frontend/Playground.tsx
+++ b/ui/frontend/Playground.tsx
@@ -7,7 +7,7 @@ import Header from './Header';
 import Output from './Output';
 import { Focus } from './reducers/output/meta';
 import State from './state';
-import { Orientation } from './types';
+import { Orientation, PageMode } from './types';
 
 const ConfigurationModal: React.SFC = () => (
   <div className="modal-backdrop">
@@ -17,14 +17,14 @@ const ConfigurationModal: React.SFC = () => (
   </div>
 );
 
-const Playground: React.SFC<Props> = ({ showConfig, focus, splitOrientation }) => {
+const Playground: React.SFC<Props> = ({ showConfig, focus, splitOrientation, pageMode }) => {
   const config = showConfig ? <ConfigurationModal /> : null;
   const outputFocused = focus ? 'playground-output-focused' : '';
   const splitClass = 'playground-split';
   const orientation = splitClass + '-' + splitOrientation;
 
   return (
-    <div>
+    <div className={`playground-mode-${pageMode}`}>
       {config}
       <div className="playground">
         <div className="playground-header">
@@ -45,11 +45,13 @@ const Playground: React.SFC<Props> = ({ showConfig, focus, splitOrientation }) =
 
 interface Props {
   focus?: Focus;
+  pageMode: PageMode;
   showConfig: boolean;
   splitOrientation: Orientation;
 }
 
 const mapStateToProps = (state: State) => ({
+  pageMode: state.configuration.pageMode,
   showConfig: state.configuration.shown,
   focus: state.output.meta.focus,
   splitOrientation: state.configuration.orientation,

--- a/ui/frontend/actions.ts
+++ b/ui/frontend/actions.ts
@@ -12,6 +12,7 @@ import {
   Mode,
   Orientation,
   Page,
+  PageMode,
   ProcessAssembly,
 } from './types';
 
@@ -49,6 +50,7 @@ export enum ActionType {
   ToggleConfiguration = 'TOGGLE_CONFIGURATION',
   SetPage = 'SET_PAGE',
   ChangeEditor = 'CHANGE_EDITOR',
+  ChangePageMode = 'CHANGE_PAGE_MODE',
   ChangeKeybinding = 'CHANGE_KEYBINDING',
   ChangeTheme = 'CHANGE_THEME',
   ChangeOrientation = 'CHANGE_ORIENTATION',
@@ -84,6 +86,7 @@ export type Action =
   | ChangeChannelAction
   | ChangeDemangleAssemblyAction
   | ChangeEditorAction
+  | ChangePageModeAction
   | ChangeFocusAction
   | ChangeProcessAssemblyAction
   | ChangeKeybindingAction
@@ -121,6 +124,11 @@ export interface SetPageAction {
 export interface ChangeEditorAction {
   type: ActionType.ChangeEditor;
   editor: Editor;
+}
+
+export interface ChangePageModeAction {
+  type: ActionType.ChangePageMode;
+  pageMode: PageMode;
 }
 
 export interface ChangeKeybindingAction {
@@ -178,6 +186,10 @@ export function changeEditor(editor): ChangeEditorAction {
 
 export function changeKeybinding(keybinding): ChangeKeybindingAction {
   return { type: ActionType.ChangeKeybinding, keybinding };
+}
+
+export function changePageMode(pageMode): ChangePageModeAction {
+  return { type: ActionType.ChangePageMode, pageMode };
 }
 
 export function changeTheme(theme): ChangeThemeAction {
@@ -645,9 +657,11 @@ function parseMode(s: string): Mode | null {
   }
 }
 
-export function indexPageLoad({ code, gist, version = 'stable', mode: modeString = 'debug' }): ThunkAction {
+export function indexPageLoad({ code, gist, version = 'stable', mode: modeString = 'debug', pageMode = PageMode.Normal }): ThunkAction {
   return function(dispatch) {
     dispatch(navigateToIndex());
+
+    dispatch(changePageMode(pageMode));
 
     if (code) {
       dispatch(editCode(code));

--- a/ui/frontend/index.scss
+++ b/ui/frontend/index.scss
@@ -27,7 +27,6 @@ html {
 
 body {
     background-color: $background;
-    padding: 0 1em;
     font-family: $primary-font;
 }
 
@@ -51,12 +50,93 @@ body {
     margin-bottom: 4px;
 }
 
+@mixin body-monospace-presentation {
+    font-size: 1.9em;
+    // http://code.stephenmorley.org/html-and-css/fixing-browsers-broken-monospace-font-handling/
+    // ACE uses Monaco, Menlo, "Ubuntu Mono", Consolas, source-code-pro, monospace;
+    font-family: 'Source Code Pro', monospace;
+}
+
+@mixin body-monospace {
+    font-size: 0.9em;
+    // http://code.stephenmorley.org/html-and-css/fixing-browsers-broken-monospace-font-handling/
+    // ACE uses Monaco, Menlo, "Ubuntu Mono", Consolas, source-code-pro, monospace;
+    font-family: 'Source Code Pro', monospace;
+}
+
+.playground-mode-presentation {
+
+    &:hover {
+        .playground-header {
+            display:block;
+        }
+    }
+
+    .playground-header {
+        display:none;
+        z-index: 20;
+        position: absolute;
+        top: 3px;
+        right: 3px;
+    }
+
+    #editor {
+        @include body-monospace-presentation;
+    }
+
+    .editor {
+        &-simple {
+            @include body-monospace-presentation;
+        }
+    }
+
+    .output {
+        .code {
+            @include body-monospace-presentation;
+        }
+    }
+
+    .playground {
+        padding: 0;
+
+        &-editor {
+            border:none;
+        }
+    }
+
+    .header {
+        padding:0;
+
+        .header-set {
+            margin-left:0.3em;
+        }
+
+        .header-set__btn--primary {
+            font-size: 0.7rem;
+        }
+
+        .header-set__btn {
+            font-size: 0.7rem;
+        }
+
+        .header-set__radio-label {
+            font-size: 0.7rem;
+            padding: 0.12em;
+        }
+
+        .header-set__title {
+            display:none;
+        }
+    }
+
+}
+
 .playground {
     display: flex;
     height: 100vh;
     flex-direction: column;
 
-    padding-bottom: 1em;
+    padding: 0 1em 1em 1em;
 
     &-split {
         display: flex;
@@ -144,12 +224,7 @@ body {
     }
 }
 
-@mixin body-monospace {
-    font-size: 0.9em;
-    // http://code.stephenmorley.org/html-and-css/fixing-browsers-broken-monospace-font-handling/
-    // ACE uses Monaco, Menlo, "Ubuntu Mono", Consolas, source-code-pro, monospace;
-    font-family: 'Source Code Pro', monospace;
-}
+
 
 .header {
     display: flex;

--- a/ui/frontend/reducers/configuration.ts
+++ b/ui/frontend/reducers/configuration.ts
@@ -6,6 +6,7 @@ import {
   Editor,
   Mode,
   Orientation,
+  PageMode,
   ProcessAssembly,
 } from '../types';
 
@@ -20,6 +21,7 @@ export interface State {
   processAssembly: ProcessAssembly;
   channel: Channel;
   mode: Mode;
+  pageMode: PageMode
 }
 
 export const DEFAULT: State = {
@@ -33,12 +35,15 @@ export const DEFAULT: State = {
   processAssembly: ProcessAssembly.Filter,
   channel: Channel.Stable,
   mode: Mode.Debug,
+  pageMode: PageMode.Normal
 };
 
 export default function configuration(state = DEFAULT, action: Action): State {
   switch (action.type) {
   case ActionType.ToggleConfiguration:
     return { ...state, shown: !state.shown };
+  case ActionType.ChangePageMode:
+    return { ...state, pageMode: action.pageMode };
   case ActionType.ChangeEditor:
     return { ...state, editor: action.editor };
   case ActionType.ChangeKeybinding:

--- a/ui/frontend/types.ts
+++ b/ui/frontend/types.ts
@@ -29,6 +29,10 @@ export enum Editor {
   Simple = 'simple',
   Advanced = 'advanced',
 }
+export enum PageMode {
+  Normal = 'normal',
+  Presentation = 'presentation',
+}
 
 export enum Orientation {
   Automatic = 'automatic',


### PR DESCRIPTION
i created a minimalistic presentation mode.
most time if i give talks about languages i embed a live editor like the rust-playground.

when i tryed to embed the rust playground in my slides, i had some issues (small font, large header, ...).

the presentation mode is designed to be embedded as iframe to presentations.
http://127.0.0.1:5000/?pageMode=presentation&code=example_code

for example slides like https://ashleygwilliams.github.io/a-very-brief-intro-to-rust/#18 could directly embed the rust playpen.

![presentation_mode](https://user-images.githubusercontent.com/689269/38392153-d15e190e-3926-11e8-9a01-b65a2d727d57.png)

please review carefully, first time typescript and redux for me ;) 
