### PR TITLE
Removes $ sign when importing gist with multiple files

### DIFF
--- a/ui/src/gist.rs
+++ b/ui/src/gist.rs
@@ -28,7 +28,7 @@ impl From<gists::Gist> for Gist {
             _ => {
                 files
                     .into_iter()
-                    .map(|(name, content)| format!("// ${}\n\n${}\n\n", name, content))
+                    .map(|(name, content)| format!("// ${}\n\n{}\n\n", name, content))
                     .collect()
             }
         };


### PR DESCRIPTION
When you import a gist with multiple files via url, $ is added at the beginning of each file, which causes compilation error:

https://github.com/integer32llc/rust-playground/issues/289

So this change fixes the problem.