### PR TITLE
Redesign the playground's header

### DIFF
--- a/tests/spec/features/compilation_modes_spec.rb
+++ b/tests/spec/features/compilation_modes_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Compiling in different modes", type: :feature, js: true do
   end
 
   scenario "compiling in debug mode" do
-    choose_styled("Debug")
+    in_mode_menu { click_on("Debug") }
     click_on("Run")
 
     within('.output-stdout') do
@@ -21,7 +21,7 @@ RSpec.feature "Compiling in different modes", type: :feature, js: true do
   end
 
   scenario "compiling in release mode" do
-    choose_styled("Release")
+    in_mode_menu { click_on("Release") }
     click_on("Run")
 
     within('.output-stdout') do

--- a/tests/spec/features/compilation_targets_spec.rb
+++ b/tests/spec/features/compilation_targets_spec.rb
@@ -12,13 +12,11 @@ RSpec.feature "Compiling to different formats", type: :feature, js: true do
 
   context "when AT&T syntax is selected" do
     before do
-      click_on("Config")
-      select("AT&T")
-      click_on("Done")
+      in_config_menu { choose("AT&T") }
     end
 
     scenario "compiling to assembly" do
-      within('.header') { click_on("ASM") }
+      in_build_menu { click_on("assembly") }
 
       within('.output-code') do
         # We demangle the symbols
@@ -31,13 +29,11 @@ RSpec.feature "Compiling to different formats", type: :feature, js: true do
 
   context "when Intel syntax is selected" do
     before do
-      click_on("Config")
-      select("Intel")
-      click_on("Done")
+      in_config_menu { choose("Intel") }
     end
 
     scenario "compiling to assembly" do
-      within('.header') { click_on("ASM") }
+      in_build_menu { click_on("assembly") }
 
       within('.output-code') do
         # We demangle the symbols
@@ -49,7 +45,7 @@ RSpec.feature "Compiling to different formats", type: :feature, js: true do
   end
 
   scenario "compiling to LLVM IR" do
-    within('.header') { click_on("LLVM IR") }
+    in_build_menu { click_on("LLVM IR") }
 
     within('.output-code') do
       expect(page).to have_content 'ModuleID'
@@ -59,7 +55,7 @@ RSpec.feature "Compiling to different formats", type: :feature, js: true do
   end
 
   scenario "compiling to MIR" do
-    within('.header') { click_on("MIR") }
+    in_build_menu { click_on("MIR") }
 
     within('.output-code') do
       expect(page).to have_content 'StorageLive'
@@ -68,10 +64,7 @@ RSpec.feature "Compiling to different formats", type: :feature, js: true do
   end
 
   scenario "compiling to WebAssembly" do
-    within('.header') do
-      choose_styled("Nightly")
-      click_on("WASM")
-    end
+    in_build_menu { click_on("WASM") }
 
     within('.output-code') do
       expect(page).to have_content '(module'
@@ -83,7 +76,7 @@ RSpec.feature "Compiling to different formats", type: :feature, js: true do
     before { editor.set("fn main() {") }
 
     scenario "it shows the compilation error" do
-      within('.header') { click_on("MIR") }
+      in_build_menu { click_on("MIR") }
 
       within('.output-stderr') do
         expect(page).to have_content 'an un-closed delimiter'

--- a/tests/spec/features/editor_types_spec.rb
+++ b/tests/spec/features/editor_types_spec.rb
@@ -1,12 +1,13 @@
 require 'spec_helper'
+require 'support/playground_actions'
 
 RSpec.feature "Editing in different editors", type: :feature, js: true do
+  include PlaygroundActions
+
   before { visit '/' }
 
   scenario "using the simple editor" do
-    click_on("Config")
-    select("Simple")
-    click_on("Done")
+    in_config_menu { choose("simple") }
 
     fill_in('editor-simple', with: simple_editor_code)
 

--- a/tests/spec/features/multiple_channels_spec.rb
+++ b/tests/spec/features/multiple_channels_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Multiple Rust versions", type: :feature, js: true do
   end
 
   scenario "using stable Rust" do
-    choose_styled("Stable")
+    in_channel_menu { click_on("Stable") }
     click_on("Run")
 
     within('.output-stdout') do
@@ -22,7 +22,7 @@ RSpec.feature "Multiple Rust versions", type: :feature, js: true do
   end
 
   scenario "using beta Rust" do
-    choose_styled("Beta")
+    in_channel_menu { click_on("Beta") }
     click_on("Run")
 
     within('.output-stdout') do
@@ -33,7 +33,7 @@ RSpec.feature "Multiple Rust versions", type: :feature, js: true do
   end
 
   scenario "using nightly Rust" do
-    choose_styled("Nightly")
+    in_channel_menu { click_on("Nightly") }
     click_on("Run")
 
     within('.output-stdout') do

--- a/tests/spec/features/navigation_spec.rb
+++ b/tests/spec/features/navigation_spec.rb
@@ -25,19 +25,19 @@ RSpec.feature "Navigating between pages", type: :feature, js: true do
 
   scenario "Mode and channel buttons update the URL" do
     visit '/'
-    expect(page).to have_content('Run')
+    expect(page).to have_content('RUN')
 
     editor.set("dummy")
     expect(page).to be_at_url('/')
 
-    choose_styled('Release')
+    in_mode_menu { click_on('Release') }
     expect(page).to be_at_url('/', version: 'stable', mode: 'release')
 
     go_back
     expect(page).to be_at_url('/')
 
-    choose_styled('Release')
-    choose_styled('Beta')
+    in_mode_menu { click_on('Release') }
+    in_channel_menu { click_on('Beta') }
     expect(page).to be_at_url('/', version: 'beta', mode: 'release')
 
     go_back
@@ -47,15 +47,15 @@ RSpec.feature "Navigating between pages", type: :feature, js: true do
 
   scenario "Navigating to help changes the URL" do
     visit '/'
-    expect(page).to have_content('Run')
+    expect(page).to have_content('RUN')
 
-    click_on '?'
+    click_on 'View help'
     expect(page).to be_at_url('/help')
     expect(page).to have_content('The Rust Playground')
 
     go_back
     expect(page).to be_at_url('/')
-    expect(page).to have_content('Run')
+    expect(page).to have_content('RUN')
 
     go_forward
     expect(page).to be_at_url('/help')
@@ -63,7 +63,7 @@ RSpec.feature "Navigating between pages", type: :feature, js: true do
 
     click_on "Return to the playground"
     expect(page).to be_at_url('/')
-    expect(page).to have_content('Run')
+    expect(page).to have_content('RUN')
   end
 
   scenario "Navigating from help changes the URL" do
@@ -72,7 +72,7 @@ RSpec.feature "Navigating between pages", type: :feature, js: true do
 
     click_on "Return to the playground"
     expect(page).to be_at_url('/')
-    expect(page).to have_content('Run')
+    expect(page).to have_content('RUN')
   end
 
   def editor

--- a/tests/spec/features/tools_spec.rb
+++ b/tests/spec/features/tools_spec.rb
@@ -2,13 +2,16 @@
 
 require 'spec_helper'
 require 'support/editor'
+require 'support/playground_actions'
 
 RSpec.feature "Using third-party Rust tools", type: :feature, js: true do
+  include PlaygroundActions
+
   before { visit '/' }
 
   scenario "formatting code" do
     editor.set 'fn main() { [1,2,3,4]; }'
-    within('.header') { click_on("Format") }
+    in_tools_menu { click_on("Rustfmt") }
 
     within('#editor') do
       expect(editor).to have_line '[1, 2, 3, 4];'
@@ -17,7 +20,7 @@ RSpec.feature "Using third-party Rust tools", type: :feature, js: true do
 
   scenario "linting code with Clippy" do
     editor.set code_with_lint_warnings
-    within('.header') { click_on("Clippy") }
+    in_tools_menu { click_on("Clippy") }
 
     within(".output-stderr") do
       expect(page).to have_content 'deny(eq_op)'

--- a/tests/spec/features/url_parameters_spec.rb
+++ b/tests/spec/features/url_parameters_spec.rb
@@ -1,12 +1,22 @@
+# coding: utf-8
+
 require 'spec_helper'
 require 'support/editor'
 
 RSpec.feature "Configuration by URL parameters", type: :feature, js: true do
-  # Our headers hide the radio button proper, so we need to enable
-  # looking for invisible elements.
-  RSpec::Matchers.define :have_checked_header do |expected|
+  RSpec::Matchers.define :have_mode do |expected|
     match do |actual|
-      expect(actual).to have_checked_field(expected, visible: false)
+      within actual.find_button("Mode — Choose the optimization level") do |page|
+        expect(page).to have_text(expected)
+      end
+    end
+  end
+
+  RSpec::Matchers.define :have_channel do |expected|
+    match do |actual|
+      within actual.find_button("Channel — Choose the Rust version") do |page|
+        expect(page).to have_text(expected)
+      end
     end
   end
 
@@ -26,7 +36,7 @@ RSpec.feature "Configuration by URL parameters", type: :feature, js: true do
   scenario "loading from a Gist with a channel preserves the channel" do
     visit '/?gist=20fb1e0475f890d0fdb7864e3ad0820c&version=beta'
 
-    expect(page).to have_checked_header('Beta')
+    expect(page).to have_channel('Beta')
   end
 
   scenario "loading code directly from a parameter" do
@@ -38,13 +48,13 @@ RSpec.feature "Configuration by URL parameters", type: :feature, js: true do
   scenario "loading with a channel" do
     visit '/?version=nightly'
 
-    expect(page).to have_checked_header('Nightly')
+    expect(page).to have_channel('Nightly')
   end
 
   scenario "loading with a mode" do
     visit '/?mode=release'
 
-    expect(page).to have_checked_header('Release')
+    expect(page).to have_mode('Release')
   end
 
   def editor

--- a/tests/spec/spec_helper.rb
+++ b/tests/spec/spec_helper.rb
@@ -43,6 +43,7 @@ Capybara.default_driver = :firefox
 Capybara.app_host = "http://#{ADDRESS}:#{PORT}"
 Capybara.run_server = false
 Capybara.default_max_wait_time = 5
+Capybara.automatic_label_click = true
 
 RSpec.configure do |config|
   config.before do

--- a/tests/spec/support/playground_actions.rb
+++ b/tests/spec/support/playground_actions.rb
@@ -1,5 +1,32 @@
+# coding: utf-8
+
 module PlaygroundActions
-  def choose_styled(label)
-    find('label', text: label).click
+  def in_build_menu(&block)
+    in_menu("Select what to build", &block)
+  end
+
+  def in_mode_menu(&block)
+    in_menu("Mode — Choose the optimization level", &block)
+  end
+
+  def in_channel_menu(&block)
+    in_menu("Channel — Choose the Rust version", &block)
+  end
+
+  def in_tools_menu(&block)
+    in_menu("Tools", &block)
+  end
+
+  def in_config_menu(&block)
+    in_menu("Config", close: true, &block)
+  end
+
+  private
+
+  def in_menu(button_locator, close: false)
+    click_on(button_locator)
+    yield
+  ensure
+    click_on(button_locator) if close
   end
 end

--- a/ui/frontend/BuildMenu.tsx
+++ b/ui/frontend/BuildMenu.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const BuildMenu = () => (
+  <span>BuildMenu</span>
+);
+
+export default BuildMenu;

--- a/ui/frontend/BuildMenu.tsx
+++ b/ui/frontend/BuildMenu.tsx
@@ -1,7 +1,59 @@
 import React from 'react';
+import { connect } from 'react-redux';
 
-const BuildMenu = () => (
-  <span>BuildMenu</span>
+import {
+  changeChannel,
+  performCompileToAssembly,
+  performCompileToLLVM,
+  performCompileToMir,
+  performCompileToNightlyWasm,
+  performExecute,
+} from './actions';
+
+import { Channel } from './types';
+
+import ButtonMenuItem from './ButtonMenuItem';
+import MenuGroup from './MenuGroup';
+
+interface BuildMenuProps {
+  compileToAssembly: () => any;
+  compileToLLVM: () => any;
+  compileToMir: () => any;
+  compileToWasm: () => any;
+  execute: () => any;
+  close: () => void;
+}
+
+const BuildMenu: React.SFC<BuildMenuProps> = props => (
+  <MenuGroup title="What do you want to do?">
+    <ButtonMenuItem name="Build" onClick={() => { props.execute(); props.close(); }}>
+      No bells and whistles, regular build coming right&nbsp;up&nbsp;:D
+    </ButtonMenuItem>
+    <ButtonMenuItem name="ASM" onClick={() => { props.compileToAssembly(); props.close(); }}>
+      Build and show the resulting assembly code.
+    </ButtonMenuItem>
+    <ButtonMenuItem name="LLVM IR" onClick={() => { props.compileToLLVM(); props.close(); }}>
+      Build and show the resulting LLVM IR, LLVM's intermediate representation.
+    </ButtonMenuItem>
+    <ButtonMenuItem name="MIR" onClick={() => { props.compileToMir(); props.close(); }}>
+      Build and show the resulting MIR, Rust's intermediate representation.
+    </ButtonMenuItem>
+    <ButtonMenuItem name="WASM" onClick={() => { props.compileToWasm(); props.close(); }}>
+      Build a WebAssembly module for web browsers, in the .WAT textual representation.
+      <p className="build-menu__aside">
+        Note: WASM currently requires using the Nightly channel, selecting this
+        option will switch to Nightly.
+      </p>
+    </ButtonMenuItem>
+  </MenuGroup >
 );
 
-export default BuildMenu;
+const mapDispatchToProps = ({
+  compileToAssembly: performCompileToAssembly,
+  compileToLLVM: performCompileToLLVM,
+  compileToMir: performCompileToMir,
+  compileToWasm: performCompileToNightlyWasm,
+  execute: performExecute,
+});
+
+export default connect(undefined, mapDispatchToProps)(BuildMenu);

--- a/ui/frontend/ButtonMenuItem.tsx
+++ b/ui/frontend/ButtonMenuItem.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+import MenuItem from './MenuItem';
+
+interface ButtonMenuItemProps extends React.HTMLProps<HTMLButtonElement> {
+  name: string;
+}
+
+const ButtonMenuItem: React.SFC<ButtonMenuItemProps> = ({ name, children, ...props }) => (
+  <MenuItem>
+    <button className="button-menu-item" {...props}>
+      <div className="button-menu-item__name">{name}</div>
+      <div className="button-menu-item__description">{children}</div>
+    </button>
+  </MenuItem>
+);
+
+export default ButtonMenuItem;

--- a/ui/frontend/ChannelMenu.tsx
+++ b/ui/frontend/ChannelMenu.tsx
@@ -1,7 +1,83 @@
-import React from 'react';
+import React, { Fragment } from 'react';
+import { connect } from 'react-redux';
 
-const ChannelMenu = () => (
-  <span>ChannelMenu</span>
+import MenuGroup from './MenuGroup';
+import SelectOne from './SelectOne';
+
+import { changeChannel } from './actions';
+import {
+  betaVersionDetailsText,
+  betaVersionText,
+  nightlyVersionDetailsText,
+  nightlyVersionText,
+  stableVersionText,
+} from './selectors';
+import State from './state';
+import { Channel } from './types';
+
+interface ChannelMenuProps {
+  channel: Channel;
+  changeChannel: (_: Channel) => any;
+  stableVersion: string;
+  betaVersion: string;
+  nightlyVersion: string;
+  betaVersionDetails: string;
+  nightlyVersionDetails: string;
+  close: () => void;
+}
+
+const ChannelMenu: React.SFC<ChannelMenuProps> = props => (
+  <Fragment>
+    <MenuGroup title="Channel &mdash; Choose the rust version">
+      <SelectOne
+        name="Stable channel"
+        currentValue={props.channel}
+        thisValue={Channel.Stable}
+        changeValue={channel => { props.changeChannel(channel); props.close(); }}
+      >
+        <Desc>Build using the Stable version: {props.stableVersion}</Desc>
+      </SelectOne>
+      <SelectOne
+        name="Beta channel"
+        currentValue={props.channel}
+        thisValue={Channel.Beta}
+        changeValue={channel => { props.changeChannel(channel); props.close(); }}
+      >
+        <Desc>Build using the Beta version: {props.betaVersion}</Desc>
+        <Desc>({props.betaVersionDetails})</Desc>
+      </SelectOne>
+      <SelectOne
+        name="Nightly channel"
+        currentValue={props.channel}
+        thisValue={Channel.Nightly}
+        changeValue={channel => { props.changeChannel(channel); props.close(); }}
+      >
+        <Desc>Build using the Nightly version: {props.nightlyVersion}</Desc>
+        <Desc>({props.nightlyVersionDetails})</Desc>
+      </SelectOne>
+    </MenuGroup>
+  </Fragment>
 );
 
-export default ChannelMenu;
+const Desc: React.SFC<{}> = ({ children }) => (
+  <p className="channel-menu__description">{children}</p>
+);
+
+const mapStateToProps = (state: State) => {
+  const { configuration: { channel } } = state;
+
+  return {
+    channel,
+    stableVersion: stableVersionText(state),
+    betaVersion: betaVersionText(state),
+    nightlyVersion: nightlyVersionText(state),
+    betaVersionDetails: betaVersionDetailsText(state),
+    nightlyVersionDetails: nightlyVersionDetailsText(state),
+  };
+};
+
+const mapDispatchToProps = {
+  changeChannel,
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(ChannelMenu);

--- a/ui/frontend/ChannelMenu.tsx
+++ b/ui/frontend/ChannelMenu.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const ChannelMenu = () => (
+  <span>ChannelMenu</span>
+);
+
+export default ChannelMenu;

--- a/ui/frontend/ConfigElement.tsx
+++ b/ui/frontend/ConfigElement.tsx
@@ -1,0 +1,63 @@
+import React, { Fragment } from 'react';
+
+import MenuItem from './MenuItem';
+
+interface EitherProps extends ConfigElementProps {
+  id: string;
+  a: string;
+  b: string;
+  aLabel?: string;
+  bLabel?: string;
+  value: string;
+  onChange: (_: string) => any;
+}
+
+export const Either: React.SFC<EitherProps> =
+  ({ id, name, a, b, aLabel = a, bLabel = b, value, onChange }) => (
+    <ConfigElement name={name}>
+      <div className="config-element__toggle">
+        <input id={`${id}-a`}
+          name={id}
+          value={a}
+          type="radio"
+          checked={value === a}
+          onChange={() => onChange(a)} />
+        <label htmlFor={`${id}-a`}>{aLabel}</label>
+        <input id={`${id}-b`}
+          name={id}
+          value={b}
+          type="radio"
+          checked={value === b}
+          onChange={() => onChange(b)} />
+        <label htmlFor={`${id}-b`}>{bLabel}</label>
+      </div>
+    </ConfigElement>
+  );
+
+interface SelectProps extends ConfigElementProps {
+  value: string;
+  onChange: (_: string) => any;
+}
+
+export const Select: React.SFC<SelectProps> = ({ name, value, onChange, children }) => (
+  <ConfigElement name={name}>
+    <select className="config-element__select" value={value} onChange={e => onChange(e.target.value)}>
+      {children}
+    </select>
+  </ConfigElement>
+);
+
+interface ConfigElementProps {
+  name: string;
+}
+
+const ConfigElement: React.SFC<ConfigElementProps> = ({ name, children }) => (
+  <MenuItem>
+    <div className="config-element">
+      <span className="config-element__name">{name}</span>
+      <div className="config-element__value">
+        {children}
+      </div>
+    </div>
+  </MenuItem >
+);

--- a/ui/frontend/ConfigMenu.tsx
+++ b/ui/frontend/ConfigMenu.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const ConfigMenu = () => (
+  <span>ConfigMenu</span>
+);
+
+export default ConfigMenu;

--- a/ui/frontend/ConfigMenu.tsx
+++ b/ui/frontend/ConfigMenu.tsx
@@ -1,7 +1,140 @@
-import React from 'react';
+/* global ACE_KEYBINDINGS:false, ACE_THEMES:false */
 
-const ConfigMenu = () => (
-  <span>ConfigMenu</span>
+import React, { Fragment } from 'react';
+import { connect } from 'react-redux';
+
+import { Either as EitherConfig, Select as SelectConfig } from './ConfigElement';
+import MenuGroup from './MenuGroup';
+
+import {
+  changeAssemblyFlavor,
+  changeDemangleAssembly,
+  changeEditor,
+  changeKeybinding,
+  changeOrientation,
+  changeProcessAssembly,
+  changeTheme,
+  toggleConfiguration,
+} from './actions';
+import State from './state';
+import { AssemblyFlavor, DemangleAssembly, Editor, Orientation, ProcessAssembly } from './types';
+
+interface ConfigMenuProps {
+  assemblyFlavor: AssemblyFlavor;
+  changeAssemblyFlavor: (_: AssemblyFlavor) => any;
+  changeDemangleAssembly: (_: DemangleAssembly) => any;
+  changeEditorStyle: (_: Editor) => any;
+  changeKeybinding: (_: string) => any;
+  changeOrientation: (_: Orientation) => any;
+  changeProcessAssembly: (_: ProcessAssembly) => any;
+  changeTheme: (_: string) => any;
+  demangleAssembly: DemangleAssembly;
+  editorStyle: Editor;
+  keybinding: string;
+  orientation: Orientation;
+  processAssembly: ProcessAssembly;
+  theme: string;
+  close: () => void;
+}
+
+const ConfigMenu: React.SFC<ConfigMenuProps> = props => (
+  <Fragment>
+    <MenuGroup title="Editor">
+      <EitherConfig
+        id="editor-style"
+        name="Style"
+        a={Editor.Simple}
+        b={Editor.Advanced}
+        value={props.editorStyle}
+        onChange={props.changeEditorStyle} />
+
+      {props.editorStyle === Editor.Advanced && (
+        <Fragment>
+          <SelectConfig
+            name="Keybinding"
+            value={props.keybinding}
+            onChange={props.changeKeybinding}
+          >
+            {ACE_KEYBINDINGS.map(k => <option key={k} value={k}>{k}</option>)}
+          </SelectConfig>
+
+          <SelectConfig
+            name="Theme"
+            value={props.theme}
+            onChange={props.changeTheme}
+          >
+            {ACE_THEMES.map(t => <option key={t} value={t}>{t}</option>)}
+          </SelectConfig>
+        </Fragment>
+      )}
+    </MenuGroup>
+
+    <MenuGroup title="UI">
+      <SelectConfig
+        name="Orientation"
+        value={props.orientation}
+        onChange={props.changeOrientation}
+      >
+        <option value={Orientation.Automatic}>Automatic</option>
+        <option value={Orientation.Horizontal}>Horizontal</option>
+        <option value={Orientation.Vertical}>Vertical</option>
+      </SelectConfig>
+    </MenuGroup>
+
+    <MenuGroup title="Assembly">
+      <EitherConfig
+        id="assembly-flavor"
+        name="Flavor"
+        a={AssemblyFlavor.Att}
+        b={AssemblyFlavor.Intel}
+        aLabel="AT&T"
+        bLabel="Intel"
+        value={props.assemblyFlavor}
+        onChange={props.changeAssemblyFlavor} />
+
+      <EitherConfig
+        id="assembly-symbols"
+        name="Symbol Demangling"
+        a={DemangleAssembly.Demangle}
+        b={DemangleAssembly.Mangle}
+        aLabel="On"
+        bLabel="Off"
+        value={props.demangleAssembly}
+        onChange={props.changeDemangleAssembly}
+      />
+
+      <EitherConfig
+        id="assembly-view"
+        name="Name Filtering"
+        a={ProcessAssembly.Filter}
+        b={ProcessAssembly.Raw}
+        aLabel="On"
+        bLabel="Off"
+        value={props.processAssembly}
+        onChange={props.changeProcessAssembly}
+      />
+    </MenuGroup>
+  </Fragment>
 );
 
-export default ConfigMenu;
+const mapStateToProps = (state: State) => ({
+  keybinding: state.configuration.keybinding,
+  theme: state.configuration.theme,
+  orientation: state.configuration.orientation,
+  editorStyle: state.configuration.editor,
+  assemblyFlavor: state.configuration.assemblyFlavor,
+  demangleAssembly: state.configuration.demangleAssembly,
+  processAssembly: state.configuration.processAssembly,
+});
+
+const mapDispatchToProps = ({
+  changeTheme,
+  changeKeybinding,
+  changeOrientation,
+  changeEditorStyle: changeEditor,
+  changeAssemblyFlavor,
+  changeProcessAssembly,
+  changeDemangleAssembly,
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(ConfigMenu);

--- a/ui/frontend/Header.tsx
+++ b/ui/frontend/Header.tsx
@@ -80,9 +80,9 @@ const Header: React.SFC<HeaderProps> = props => (
     </HeaderSet>
     <HeaderSet id="config">
       <SegmentedButtonSet>
-        <PopButton button={ConfigMenuButton}>
-          <ConfigMenu />
-        </PopButton>
+        <PopButton button={ConfigMenuButton}>{({ popButtonClose }) => (
+          <ConfigMenu close={popButtonClose} />
+        )}</PopButton>
       </SegmentedButtonSet>
     </HeaderSet>
     <HeaderSet id="help">

--- a/ui/frontend/Header.tsx
+++ b/ui/frontend/Header.tsx
@@ -73,9 +73,9 @@ const Header: React.SFC<HeaderProps> = props => (
     </HeaderSet>
     <HeaderSet id="tools">
       <SegmentedButtonSet>
-        <PopButton button={ToolsMenuButton}>
-          <ToolsMenu />
-        </PopButton>
+        <PopButton button={ToolsMenuButton}>{({ popButtonClose }) => (
+          <ToolsMenu close={popButtonClose} />
+        )}</PopButton>
       </SegmentedButtonSet>
     </HeaderSet>
     <HeaderSet id="config">

--- a/ui/frontend/Header.tsx
+++ b/ui/frontend/Header.tsx
@@ -55,9 +55,9 @@ const Header: React.SFC<HeaderProps> = props => (
     <HeaderSet id="channel-mode">
       <SegmentedButtonSet>
         <PopButton
-          button={p => <ModeMenuButton label={props.modeLabel} {...p} />}>
-          <ModeMenu />
-        </PopButton>
+          button={p => <ModeMenuButton label={props.modeLabel} {...p} />}>{({ popButtonClose }) => (
+            <ModeMenu close={popButtonClose} />
+          )}</PopButton>
         <PopButton
           button={p => <ChannelMenuButton label={props.channelLabel}{...p} />}>
           <ChannelMenu />

--- a/ui/frontend/Header.tsx
+++ b/ui/frontend/Header.tsx
@@ -12,18 +12,9 @@ import { SegmentedButton, SegmentedButtonSet, SegmentedLink } from './SegmentedB
 import ToolsMenu from './ToolsMenu';
 
 import {
-  changeChannel,
-  changeMode,
   navigateToHelp,
-  performClippy,
-  performCompileToAssembly,
-  performCompileToLLVM,
-  performCompileToMir,
-  performCompileToWasm,
   performExecute,
-  performFormat,
   performGistSave,
-  toggleConfiguration,
 } from './actions';
 import {
   betaVersionText,
@@ -37,7 +28,6 @@ import {
   stableVersionText,
 } from './selectors';
 import State from './state';
-import { Channel, Mode } from './types';
 
 interface HeaderProps {
   executionLabel: string;
@@ -57,9 +47,9 @@ const Header: React.SFC<HeaderProps> = props => (
             {props.executionLabel}
           </RightIconButton>
         </SegmentedButton>
-        <PopButton button={BuildMenuButton}>
-          <BuildMenu />
-        </PopButton>
+        <PopButton button={BuildMenuButton}>{({ popButtonClose }) => (
+          <BuildMenu close={popButtonClose} />
+        )}</PopButton>
       </SegmentedButtonSet>
     </HeaderSet>
     <HeaderSet id="channel-mode">

--- a/ui/frontend/Header.tsx
+++ b/ui/frontend/Header.tsx
@@ -59,9 +59,9 @@ const Header: React.SFC<HeaderProps> = props => (
             <ModeMenu close={popButtonClose} />
           )}</PopButton>
         <PopButton
-          button={p => <ChannelMenuButton label={props.channelLabel}{...p} />}>
-          <ChannelMenu />
-        </PopButton>
+          button={p => <ChannelMenuButton label={props.channelLabel}{...p} />}>{({ popButtonClose }) => (
+            <ChannelMenu close={popButtonClose} />
+          )}</PopButton>
       </SegmentedButtonSet>
     </HeaderSet>
     <HeaderSet id="share">

--- a/ui/frontend/HeaderButton.tsx
+++ b/ui/frontend/HeaderButton.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+import { ExpandableIcon } from './Icon';
+
+interface RightIconProps {
+  icon: React.ReactNode;
+}
+
+export const RightIcon: React.SFC<HeaderButtonProps> = ({ icon, children }) => (
+  <div className="header-button header-button--has-right-icon">
+    {children}
+    <div className="header-button__right-icon">{icon}</div>
+  </div>
+);
+
+interface HeaderButtonProps {
+  icon?: React.ReactNode;
+  rightIcon?: React.ReactNode;
+  isExpandable?: boolean;
+}
+
+const HeaderButton: React.SFC<HeaderButtonProps> = ({ icon, isExpandable, children }) => {
+  const c = ['header-button'];
+
+  if (isExpandable) { c.push('header-button--expandable'); }
+  if (icon) { c.push('header-button--has-left-icon'); }
+  if (icon && !isExpandable && !children) { c.push('header-button--icon-only'); }
+
+  return (
+    <div className={c.join(' ')}>
+      {icon && <div className="header-button__left-icon">{icon}</div>}
+      {children}
+      {isExpandable && <div className="header-button__drop"><ExpandableIcon /></div>}
+    </div>
+  );
+};
+
+export default HeaderButton;

--- a/ui/frontend/Help.tsx
+++ b/ui/frontend/Help.tsx
@@ -40,7 +40,7 @@ fn main ()
 { struct Foo { a: u8, b: String, }
 match 4 {2=>{},_=>{}} }`;
 
-const LINK_EXAMPLE = 'http://play.integer32.com/?code=fn main() { println!("hello world!"); }';
+const LINK_EXAMPLE = 'https://play.integer32.com/?code=fn main() { println!("hello world!"); }';
 
 const TEST_EXAMPLE = `#[test]
 fn test_something() {
@@ -104,6 +104,7 @@ const Help = ({ navigateToIndex }: HelpProps) => (
           from <a href={CRATES_IO_URL}>crates.io</a>, the crates from
           the <a href={RUST_COOKBOOK_URL}>Rust Cookbook</a>, and all
           of their dependencies. To use a crate, add the appropriate
+          {' '}
           <Code>extern crate foo</Code> line to the code.
         </p>
 
@@ -118,9 +119,9 @@ const Help = ({ navigateToIndex }: HelpProps) => (
       <LinkableSection id="features-linting" header="Linting code" level={H3}>
         <p>
           <a href={CLIPPY_URL}>Clippy</a> is a collection of lints to catch common
-          mistakes and improve your Rust code. Click on the
+          mistakes and improve your Rust code. Click on the <strong>Clippy</strong>
           {' '}
-          <strong>Clippy</strong> button to see possible improvements to your
+          button in the <strong>Tools</strong> menu to see possible improvements to your
           code.
         </p>
 
@@ -130,9 +131,9 @@ const Help = ({ navigateToIndex }: HelpProps) => (
       <LinkableSection id="features-formatting" header="Formatting code" level={H3}>
         <p>
           <a href={RUSTFMT_URL}>rustfmt</a> is a tool for formatting Rust code
-          according to the Rust style guidelines. Click on the
+          according to the Rust style guidelines. Click on the <strong>Format</strong>
           {' '}
-          <strong>Format</strong> button to automatically reformat your code.
+          button in the <strong>Tools</strong> menu to automatically reformat your code.
         </p>
 
         <Example code={RUSTFMT_EXAMPLE} />
@@ -142,9 +143,10 @@ const Help = ({ navigateToIndex }: HelpProps) => (
         <p>
           Once you have some code worth saving or sharing, click on the
           {' '}
-          <strong>Share</strong> button. This will create an anonymous <a
-          href={GIST_URL}>GitHub Gist</a>. You will also be provided with a URL
-          to load that Gist back into the playground.
+          <strong>Share</strong> button. This will create a
+          {' '}
+          <a href={GIST_URL}>GitHub Gist</a>. You will also be provided with
+          a URL to load that Gist back into the playground.
         </p>
       </LinkableSection>
 
@@ -183,12 +185,12 @@ const Help = ({ navigateToIndex }: HelpProps) => (
 
       <LinkableSection id="features-output-formats" header="Output formats" level={H3}>
         <p>
-          Instead of compiling to a final binary, you can also see intermediate
-          output of the compiler as LLVM IR, x86_64 assembly, or Rust MIR. This
-          is often used in conjunction with the <a href="#features-modes">mode</a>
+          Instead of executing the code, you can also see intermediate
+          output of the compiler as x86_64 assembly, LLVM IR, Rust MIR, or
+          WebAssembly. This is often used in conjunction with the
           {' '}
-          selector set to "Release" to see how the compiler has chosen to optimize
-          some specific piece of code.
+          <a href="#features-modes">mode</a> set to "Release" to see how the
+          compiler has chosen to optimize some specific piece of code.
         </p>
 
         <Example code={OUTPUT_EXAMPLE} />
@@ -204,7 +206,8 @@ const Help = ({ navigateToIndex }: HelpProps) => (
 
         <p>
           You can choose which mode to compile in using the <strong>Mode</strong>
-          selector.
+          {' '}
+          menu.
         </p>
       </LinkableSection>
 
@@ -219,7 +222,7 @@ const Help = ({ navigateToIndex }: HelpProps) => (
         <p>
           You can choose which channel to compile with using the
           {' '}
-          <strong>Channel</strong> selector.
+          <strong>Channel</strong> menu.
         </p>
       </LinkableSection>
 
@@ -237,7 +240,7 @@ const Help = ({ navigateToIndex }: HelpProps) => (
         </p>
 
         <p>
-          These options can be configured via <strong>Config</strong>.
+          These options can be configured via the <strong>Config</strong> menu.
         </p>
       </LinkableSection>
 
@@ -301,15 +304,15 @@ const H3: React.SFC = ({ children }) => <h3>{children}</h3>;
 const LinkableSection: React.SFC<LinkableSectionProps> = ({
   id, header, level: Level, children,
 }) => (
-  <div id={id}>
-    <Level>
-      <span className="help__header">
-        <a className="help__header-link" href={`#${id}`}>{header}</a>
-      </span>
-    </Level>
-    {children}
-  </div>
-);
+    <div id={id}>
+      <Level>
+        <span className="help__header">
+          <a className="help__header-link" href={`#${id}`}>{header}</a>
+        </span>
+      </Level>
+      {children}
+    </div>
+  );
 
 interface LinkableSectionProps {
   id: string;
@@ -318,7 +321,7 @@ interface LinkableSectionProps {
 }
 
 const Code: React.SFC = ({ children }) => (
-    <code className="help__code">{children}</code>
+  <code className="help__code">{children}</code>
 );
 
 const mapStateToProps = () => ({

--- a/ui/frontend/Icon.tsx
+++ b/ui/frontend/Icon.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+/* tslint:disable:max-line-length */
+
+export const BuildIcon = () => (
+  <svg className="icon" height="14" viewBox="8 4 10 16" width="12" xmlns="http://www.w3.org/2000/svg">
+    <path d="M8 5v14l11-7z" />
+    <path d="M0 0h24v24H0z" fill="none" />
+  </svg>
+);
+
+export const ExpandableIcon = () => (
+  <svg className="icon" height="10" viewBox="6 8 12 8" width="10" xmlns="http://www.w3.org/2000/svg">
+    <path d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z" />
+    <path d="M0 0h24v24H0z" fill="none" />
+  </svg>
+);
+
+export const MoreOptionsIcon = () => (
+  <svg className="icon" height="18" viewBox="0 0 24 24" width="18" xmlns="http://www.w3.org/2000/svg">
+    <path d="M0 0h24v24H0z" fill="none" />
+    <path d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z" />
+  </svg>
+);
+
+export const ConfigIcon = () => (
+  <svg className="icon" height="15" viewBox="0 0 24 24" width="15" xmlns="http://www.w3.org/2000/svg">
+    <path d="M0 0h24v24H0z" fill="none" />
+    <path d="M19.43 12.98c.04-.32.07-.64.07-.98s-.03-.66-.07-.98l2.11-1.65c.19-.15.24-.42.12-.64l-2-3.46c-.12-.22-.39-.3-.61-.22l-2.49 1c-.52-.4-1.08-.73-1.69-.98l-.38-2.65C14.46 2.18 14.25 2 14 2h-4c-.25 0-.46.18-.49.42l-.38 2.65c-.61.25-1.17.59-1.69.98l-2.49-1c-.23-.09-.49 0-.61.22l-2 3.46c-.13.22-.07.49.12.64l2.11 1.65c-.04.32-.07.65-.07.98s.03.66.07.98l-2.11 1.65c-.19.15-.24.42-.12.64l2 3.46c.12.22.39.3.61.22l2.49-1c.52.4 1.08.73 1.69.98l.38 2.65c.03.24.24.42.49.42h4c.25 0 .46-.18.49-.42l.38-2.65c.61-.25 1.17-.59 1.69-.98l2.49 1c.23.09.49 0 .61-.22l2-3.46c.12-.22.07-.49-.12-.64l-2.11-1.65zM12 15.5c-1.93 0-3.5-1.57-3.5-3.5s1.57-3.5 3.5-3.5 3.5 1.57 3.5 3.5-1.57 3.5-3.5 3.5z" />
+  </svg>
+);
+
+export const HelpIcon = () => (
+  <svg className="icon" height="18" viewBox="0 0 24 24" width="18" xmlns="http://www.w3.org/2000/svg">
+    <path d="M0 0h24v24H0z" fill="none" />
+    <path d="M11 18h2v-2h-2v2zm1-16C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm0-14c-2.21 0-4 1.79-4 4h2c0-1.1.9-2 2-2s2 .9 2 2c0 2-3 1.75-3 5h2c0-2.25 3-2.5 3-5 0-2.21-1.79-4-4-4z" />
+  </svg>
+);

--- a/ui/frontend/Icon.tsx
+++ b/ui/frontend/Icon.tsx
@@ -36,3 +36,10 @@ export const HelpIcon = () => (
     <path d="M11 18h2v-2h-2v2zm1-16C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm0-14c-2.21 0-4 1.79-4 4h2c0-1.1.9-2 2-2s2 .9 2 2c0 2-3 1.75-3 5h2c0-2.25 3-2.5 3-5 0-2.21-1.79-4-4-4z" />
   </svg>
 );
+
+export const CheckmarkIcon = () => (
+  <svg className="icon icon--checkmark" height="18" viewBox="2 2 22 22" width="18" xmlns="http://www.w3.org/2000/svg">
+    <path d="M0 0h24v24H0z" fill="none" />
+    <path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z" />
+  </svg>
+);

--- a/ui/frontend/MenuGroup.tsx
+++ b/ui/frontend/MenuGroup.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+interface MenuGroupProps {
+  title: string;
+}
+
+const MenuGroup: React.SFC<MenuGroupProps> = ({ title, children }) => (
+  <div className="menu-group">
+    <h1 className="menu-group__title">{title}</h1>
+    <div className="menu-group__content">
+      {children}
+    </div>
+  </div>
+);
+
+export default MenuGroup;

--- a/ui/frontend/MenuItem.tsx
+++ b/ui/frontend/MenuItem.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const MenuItem: React.SFC<{}> = ({ children }) => (
+  <div className="menu-item">{children}</div>
+);
+
+export default MenuItem;

--- a/ui/frontend/ModeMenu.tsx
+++ b/ui/frontend/ModeMenu.tsx
@@ -1,7 +1,52 @@
-import React from 'react';
+import React, { Fragment } from 'react';
+import { connect } from 'react-redux';
 
-const ModeMenu = () => (
-  <span>ModeMenu</span>
+import MenuGroup from './MenuGroup';
+import SelectOne from './SelectOne';
+
+import { changeMode } from './actions';
+import State from './state';
+import { Mode } from './types';
+
+interface ModeMenuProps {
+  mode: Mode;
+  changeMode: (_: Mode) => any;
+  close: () => void;
+}
+
+const ModeMenu: React.SFC<ModeMenuProps> = props => (
+  <Fragment>
+    <MenuGroup title="Mode &mdash; Choose optimization level">
+      <SelectOne
+        name="Debug"
+        currentValue={props.mode}
+        thisValue={Mode.Debug}
+        changeValue={mode => { props.changeMode(mode); props.close(); }}
+      >
+        Build with debug information, without optimizations.
+      </SelectOne>
+      <SelectOne
+        name="Release"
+        currentValue={props.mode}
+        thisValue={Mode.Release}
+        changeValue={mode => { props.changeMode(mode); props.close(); }}
+      >
+        Build with optimizations turned on.
+      </SelectOne>
+    </MenuGroup>
+  </Fragment>
 );
 
-export default ModeMenu;
+const mapStateToProps = (state: State) => {
+  const { configuration: { mode } } = state;
+
+  return {
+    mode,
+  };
+};
+
+const mapDispatchToProps = {
+  changeMode,
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(ModeMenu);

--- a/ui/frontend/ModeMenu.tsx
+++ b/ui/frontend/ModeMenu.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const ModeMenu = () => (
+  <span>ModeMenu</span>
+);
+
+export default ModeMenu;

--- a/ui/frontend/PopButton.tsx
+++ b/ui/frontend/PopButton.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Arrow, Manager, Popper, Target } from 'react-popper';
+import { Portal } from 'react-portal';
 
 interface PopButtonStatelessProps {
   text: string;
@@ -18,10 +19,12 @@ const PopButtonStateless: React.SFC<PopButtonStatelessProps> =
   );
 
 const PopButtonPopper = ({ children }) => (
-  <Popper className="popper" placement="bottom">
-    <Arrow className="popper__arrow" />
-    <div className="popper__content">{children}</div>
-  </Popper>
+  <Portal>
+    <Popper className="popper" placement="bottom">
+      <Arrow className="popper__arrow" />
+      <div className="popper__content">{children}</div>
+    </Popper>
+  </Portal >
 );
 
 interface PopButtonProps {

--- a/ui/frontend/PopButton.tsx
+++ b/ui/frontend/PopButton.tsx
@@ -26,10 +26,15 @@ const PopButtonPopper = ({ children }) => (
 
 interface PopButtonProps {
   text: string;
+  children: React.ReactNode | ((_: PopButtonEnhancements) => React.ReactNode);
 }
 
 interface PopButtonState {
   isOpen: boolean;
+}
+
+export interface PopButtonEnhancements {
+  popButtonClose: () => void;
 }
 
 class PopButton extends React.Component<PopButtonProps, PopButtonState> {
@@ -44,15 +49,26 @@ class PopButton extends React.Component<PopButtonProps, PopButtonState> {
     this.setState({ isOpen: !this.state.isOpen });
   }
 
+  private close = () => {
+    this.setState({ isOpen: false });
+  }
+
   public render() {
     const { isOpen } = this.state;
     const { text, children } = this.props;
+
+    const enhancedProps = { popButtonClose: this.close };
+    const enhancedChildren =
+      typeof children === 'function' ?
+        children(enhancedProps) :
+        children;
+
     return (
       <PopButtonStateless
         text={text}
         isOpen={isOpen}
         onClick={this.handleToggleVisibility}>
-        {children}
+        {enhancedChildren}
       </PopButtonStateless>
     );
   }

--- a/ui/frontend/PopButton.tsx
+++ b/ui/frontend/PopButton.tsx
@@ -2,29 +2,44 @@ import React from 'react';
 import { Arrow, Manager, Popper, Target } from 'react-popper';
 import { Portal } from 'react-portal';
 
+type SetRefFunc = (ref: HTMLElement) => void;
+
 interface PopButtonStatelessProps {
   text: string;
   isOpen: boolean;
   onClick: () => any;
+  setButtonRef: SetRefFunc;
+  setPopperRef: SetRefFunc;
 }
 
 const PopButtonStateless: React.SFC<PopButtonStatelessProps> =
-  ({ text, children, isOpen, onClick }) => (
+  ({ text, children, isOpen, onClick, setButtonRef, setPopperRef }) => (
     <Manager tag={false}>
-      <Target>{({ targetProps }) => (
-        <button onClick={onClick} {...targetProps}>{text}</button>
+      <Target>{({ targetProps: { ref: setTargetRef, ...targetProps } }) => (
+        <button
+          onClick={onClick}
+          ref={r => { setButtonRef(r); setTargetRef(r); }}
+          {...targetProps}>
+          {text}
+        </button>
       )}</Target>
-      {isOpen && <PopButtonPopper>{children}</PopButtonPopper>}
+      {isOpen && <PopButtonPopper setPopperRef={setPopperRef}>{children}</PopButtonPopper>}
     </Manager>
   );
 
-const PopButtonPopper = ({ children }) => (
+interface PopButtonPopperProps {
+  setPopperRef: SetRefFunc;
+}
+
+const PopButtonPopper: React.SFC<PopButtonPopperProps> = ({ setPopperRef, children }) => (
   <Portal>
-    <Popper className="popper" placement="bottom">
-      <Arrow className="popper__arrow" />
-      <div className="popper__content">{children}</div>
-    </Popper>
-  </Portal >
+    <div ref={setPopperRef}>
+      <Popper className="popper" placement="bottom">
+        <Arrow className="popper__arrow" />
+        <div className="popper__content">{children}</div>
+      </Popper>
+    </div>
+  </Portal>
 );
 
 interface PopButtonProps {
@@ -41,6 +56,9 @@ export interface PopButtonEnhancements {
 }
 
 class PopButton extends React.Component<PopButtonProps, PopButtonState> {
+  private buttonRef;
+  private popperRef;
+
   constructor(props) {
     super(props);
     this.state = {
@@ -54,6 +72,33 @@ class PopButton extends React.Component<PopButtonProps, PopButtonState> {
 
   private close = () => {
     this.setState({ isOpen: false });
+  }
+
+  private setButtonRef = r => {
+    this.buttonRef = r;
+  }
+
+  private setPopperRef = r => {
+    this.popperRef = r;
+  }
+
+  private handleClickOutside = event => {
+    if (this.buttonRef && this.buttonRef.contains(event.target)) {
+      // They are clicking on the button, so let that go ahead and close us.
+      return;
+    }
+
+    if (this.popperRef && !this.popperRef.contains(event.target)) {
+      this.close();
+    }
+  }
+
+  public componentDidMount() {
+    document.addEventListener('mousedown', this.handleClickOutside);
+  }
+
+  public componentWillUnmount() {
+    document.removeEventListener('mousedown', this.handleClickOutside);
   }
 
   public render() {
@@ -70,7 +115,9 @@ class PopButton extends React.Component<PopButtonProps, PopButtonState> {
       <PopButtonStateless
         text={text}
         isOpen={isOpen}
-        onClick={this.handleToggleVisibility}>
+        onClick={this.handleToggleVisibility}
+        setButtonRef={this.setButtonRef}
+        setPopperRef={this.setPopperRef}>
         {enhancedChildren}
       </PopButtonStateless>
     );

--- a/ui/frontend/PopButton.tsx
+++ b/ui/frontend/PopButton.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { Arrow, Manager, Popper, Target } from 'react-popper';
+
+interface PopButtonStatelessProps {
+  text: string;
+  isOpen: boolean;
+  onClick: () => any;
+}
+
+const PopButtonStateless: React.SFC<PopButtonStatelessProps> =
+  ({ text, children, isOpen, onClick }) => (
+    <Manager tag={false}>
+      <Target>{({ targetProps }) => (
+        <button onClick={onClick} {...targetProps}>{text}</button>
+      )}</Target>
+      {isOpen && <PopButtonPopper>{children}</PopButtonPopper>}
+    </Manager>
+  );
+
+const PopButtonPopper = ({ children }) => (
+  <Popper className="popper" placement="bottom">
+    <Arrow className="popper__arrow" />
+    <div className="popper__content">{children}</div>
+  </Popper>
+);
+
+interface PopButtonProps {
+  text: string;
+}
+
+interface PopButtonState {
+  isOpen: boolean;
+}
+
+class PopButton extends React.Component<PopButtonProps, PopButtonState> {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isOpen: false,
+    };
+  }
+
+  private handleToggleVisibility = () => {
+    this.setState({ isOpen: !this.state.isOpen });
+  }
+
+  public render() {
+    const { isOpen } = this.state;
+    const { text, children } = this.props;
+    return (
+      <PopButtonStateless
+        text={text}
+        isOpen={isOpen}
+        onClick={this.handleToggleVisibility}>
+        {children}
+      </PopButtonStateless>
+    );
+  }
+}
+
+export default PopButton;

--- a/ui/frontend/SegmentedButton.tsx
+++ b/ui/frontend/SegmentedButton.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+import Link, { LinkProps } from './uss-router/Link';
+
+export const SegmentedButtonSet: React.SFC<{}> = ({ children }) => (
+  <div className="segmented-button">{children}</div>
+);
+
+interface SegmentedButtonProps extends React.HTMLProps<HTMLButtonElement> {
+  isBuild?: boolean;
+  innerRef: React.Ref<HTMLElement>;
+}
+
+const SegmentedButtonInner: React.SFC<SegmentedButtonProps> = ({ innerRef, isBuild, children, ...props }) => (
+  <button
+    ref={innerRef}
+    {...props}
+    className={`segmented-button__button ${isBuild ? 'segmented-button__button--build' : ''}`}>
+    {children}
+  </button>
+);
+
+export const SegmentedButton = React.forwardRef((props, ref) => (
+  <SegmentedButtonInner innerRef={ref} {...props} />
+));
+
+interface SegmentedLinkProps {
+  title?: string;
+  innerRef: React.Ref<any>;
+}
+
+const SegmentedLinkInner: React.SFC<SegmentedLinkProps> = ({ innerRef, children, ...props }) => (
+  <Link
+    ref={innerRef}
+    {...props}
+    className={'segmented-button__button'}>
+    {children}
+  </Link>
+);
+
+export const SegmentedLink = React.forwardRef((props, ref) => (
+  <SegmentedLinkInner innerRef={ref} {...props} />
+));

--- a/ui/frontend/SelectOne.tsx
+++ b/ui/frontend/SelectOne.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import SelectableMenuItem from './SelectableMenuItem';
+
+interface SelectOneProps<T> {
+  name: string;
+  currentValue: T;
+  thisValue: T;
+  changeValue: (_: T) => any;
+}
+
+export default class SelectOne<T> extends React.PureComponent<SelectOneProps<T>> {
+  public render() {
+    const { name, currentValue, thisValue, children, changeValue } = this.props;
+
+    return (
+      <SelectableMenuItem
+        name={name}
+        selected={currentValue === thisValue}
+        onClick={() => changeValue(thisValue)}>
+        {children}
+      </SelectableMenuItem>
+    );
+  }
+}

--- a/ui/frontend/SelectableMenuItem.tsx
+++ b/ui/frontend/SelectableMenuItem.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import { CheckmarkIcon } from './Icon';
+import MenuItem from './MenuItem';
+
+interface SelectableMenuItemProps extends React.HTMLProps<HTMLButtonElement> {
+  name: string;
+  selected: boolean;
+}
+
+const SelectableMenuItem: React.SFC<SelectableMenuItemProps> = ({ name, selected, children, ...props }) => (
+  <MenuItem>
+    <button className={`selectable-item ${selected ? 'selectable-item--selected' : ''}`} {...props}>
+      <div className="selectable-item__header">
+        <span className="selectable-item__checkmark">
+          <CheckmarkIcon />
+        </span>
+        <span className="selectable-item__name">{name}</span>
+      </div>
+      <div className="selectable-item__description">{children}</div>
+    </button>
+  </MenuItem>
+);
+
+export default SelectableMenuItem;

--- a/ui/frontend/ToolsMenu.tsx
+++ b/ui/frontend/ToolsMenu.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const ToolsMenu = () => (
+  <span>ToolsMenu</span>
+);
+
+export default ToolsMenu;

--- a/ui/frontend/ToolsMenu.tsx
+++ b/ui/frontend/ToolsMenu.tsx
@@ -1,7 +1,39 @@
 import React from 'react';
+import { connect } from 'react-redux';
 
-const ToolsMenu = () => (
-  <span>ToolsMenu</span>
+import ButtonMenuItem from './ButtonMenuItem';
+import MenuGroup from './MenuGroup';
+
+import {
+  performClippy,
+  performFormat,
+} from './actions';
+import State from './state';
+
+interface ToolsMenuProps {
+  clippy: () => any;
+  format: () => any;
+  close: () => void;
+}
+
+const ToolsMenu: React.SFC<ToolsMenuProps> = props => (
+  <MenuGroup title="Tools">
+    <ButtonMenuItem
+      name="Rustfmt"
+      onClick={() => { props.format(); props.close(); }}>
+      Format this code with Rustfmt.
+    </ButtonMenuItem>
+    <ButtonMenuItem
+      name="Clippy"
+      onClick={() => { props.clippy(); props.close(); }}>
+      Catch common mistakes and improve the code using the Clippy linter.
+    </ButtonMenuItem>
+  </MenuGroup>
 );
 
-export default ToolsMenu;
+const mapDispatchToProps = ({
+  clippy: performClippy,
+  format: performFormat,
+});
+
+export default connect(undefined, mapDispatchToProps)(ToolsMenu);

--- a/ui/frontend/actions.ts
+++ b/ui/frontend/actions.ts
@@ -444,6 +444,11 @@ export const performCompileToWasm = () =>
     failure: receiveCompileWasmFailure,
   });
 
+export const performCompileToNightlyWasm: ThunkAction = () => dispatch => {
+  dispatch(changeChannel(Channel.Nightly));
+  dispatch(performCompileToWasm());
+};
+
 export const EDIT_CODE = 'EDIT_CODE';
 export const GOTO_POSITION = 'GOTO_POSITION';
 

--- a/ui/frontend/augmentations/react.d.ts
+++ b/ui/frontend/augmentations/react.d.ts
@@ -1,0 +1,9 @@
+import React from 'react';
+
+type ForwardRefRender<Props, Element> = (props: Props, ref: React.Ref<Element>) => React.ReactNode;
+
+declare module 'react' {
+  // Introduced with React 16.3
+  // https://github.com/DefinitelyTyped/DefinitelyTyped/pull/24624/files
+  function forwardRef<Props, Element>(render: ForwardRefRender<Props, Element>);
+}

--- a/ui/frontend/index.ejs
+++ b/ui/frontend/index.ejs
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <title><%= htmlWebpackPlugin.options.title %></title>
-    <link href="https://fonts.googleapis.com/css?family=Open+Sans|Source+Code+Pro:400,700&subset=latin-ext" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,600,700|Source+Code+Pro:400,700&subset=latin-ext" rel="stylesheet">
   </head>
   <body>
     <div id="playground"></div>

--- a/ui/frontend/index.scss
+++ b/ui/frontend/index.scss
@@ -525,3 +525,31 @@ $PHI: 2.61803398875;
         opacity: 1;
     }
 }
+
+.popper {
+  z-index: 10;
+
+  $fg-color: #222;
+  $bg-color: white;
+  $arrow-size: 10px;
+
+  &__arrow {
+    position: absolute;
+    margin: $arrow-size;
+    border: $arrow-size solid transparent;
+  }
+
+  &[data-placement^="bottom"] &__arrow {
+    margin-top: 0;
+    border-top-width: 0;
+    border-bottom-color: $bg-color;
+  }
+
+  &__content {
+    background: $bg-color;
+    color: $fg-color;
+    border-radius: 2px;
+    box-shadow: 0 0 2px rgba(0, 0, 0, 0.5);
+    margin: $arrow-size;
+  }
+}

--- a/ui/frontend/index.scss
+++ b/ui/frontend/index.scss
@@ -29,6 +29,7 @@ body {
     background-color: $background;
     padding: 0 1em;
     font-family: $primary-font;
+    overflow-y: hidden;
 }
 
 @mixin split-first-child() {

--- a/ui/frontend/index.scss
+++ b/ui/frontend/index.scss
@@ -683,6 +683,12 @@ $header-transition: 0.2s ease-in-out;
   }
 }
 
+.channel-menu {
+  &__description {
+    margin: 0;
+  }
+}
+
 .header-button {
   height: 3em;
   padding: 0 1.25em;

--- a/ui/frontend/index.scss
+++ b/ui/frontend/index.scss
@@ -689,6 +689,72 @@ $header-transition: 0.2s ease-in-out;
   }
 }
 
+.config-element {
+  display: flex;
+  align-items: center;
+
+  &__name {
+    flex: 1;
+    font-size: 13px;
+  }
+
+  &__value {
+    flex: 1;
+  }
+
+  &__select {
+    width: 100%;
+  }
+
+  &__toggle {
+    display: flex;
+
+    input {
+      display: none;
+    }
+
+    label {
+      $border: 1px solid #bbb;
+
+      flex: 1;
+      padding: 0 1em;
+
+      text-transform: uppercase;
+      font-size: 11px;
+      font-weight: 600;
+      color: #777;
+      text-align: center;
+
+      cursor: pointer;
+
+      border: $border;
+      border-top-left-radius: $header-border-radius;
+      border-bottom-left-radius: $header-border-radius;
+      border-right-width: 0;
+
+      ~ label {
+        border-right-width: 1px;
+        border-left: $border;
+        border-radius: 0 $header-border-radius $header-border-radius 0;
+      }
+
+      &:hover {
+        background: hsla(208, 100%, 43%, 0.1);
+      }
+    }
+
+    :checked + label {
+      border-color: $header-tint;
+      background: $header-tint;
+      color: #fff;
+
+      ~ label {
+        border-left-width: 0;
+      }
+    }
+  }
+}
+
 .header-button {
   height: 3em;
   padding: 0 1.25em;

--- a/ui/frontend/index.scss
+++ b/ui/frontend/index.scss
@@ -152,125 +152,6 @@ body {
     font-family: 'Source Code Pro', monospace;
 }
 
-.header {
-    display: flex;
-    align-items: center;
-    padding: 1.25em 0;
-}
-
-.header-set {
-    $radius: 5px;
-
-    display: flex;
-    align-items: center;
-    position: relative;
-
-    margin-left: 1em;
-    &:first-of-type {
-        margin-left: 0;
-    }
-
-    &__buttons {
-        display: flex;
-
-        border-radius: $radius;
-        overflow: hidden;
-        background: white;
-        border: $border;
-
-        &--primary {
-            border-left: 0;
-            border-top-left-radius: 0;
-            border-bottom-left-radius: 0;
-        }
-
-        &--radio {
-            background-color: $unselected-radio;
-            border: 1px solid $rust;
-        }
-    }
-
-    &__btn {
-        padding: 0.5em;
-        border: none;
-        border-left: $border;
-        background: none;
-
-        &:enabled {
-            cursor: pointer;
-        }
-
-        text-decoration: none;
-        color: #000;
-
-        &:nth-child(1) {
-            border-left: 0;
-        }
-
-        &:hover:enabled {
-            background-color: darken(white, 10%);
-        }
-
-        &:disabled {
-            color: rgba(0, 0, 0, 0.5);
-        }
-
-        &--primary {
-            background-color: $rust;
-
-            color: white;
-            font-size: 1.5rem;
-
-            border-radius: $radius;
-            border: none;
-
-            &:after {
-                content: " ▶";
-            }
-
-            &:hover:enabled {
-                background-color: darken($rust, 10%);
-            }
-        }
-    }
-
-    &__radio {
-        display: none;
-
-        &-label {
-            padding: 0.5em;
-            cursor: pointer;
-            border-right: 1px solid $rust;
-
-            &:last-child {
-                border-right: 0;
-            }
-
-            &:hover {
-                background-color: desaturate($selected-radio, 10%);
-            }
-
-            :checked + & {
-                background-color: $selected-radio;
-                cursor: default;
-            }
-        }
-    }
-
-    &__title {
-        position: absolute;
-        width: 90%;
-        left: 50%;
-        transform: translateX(-50%);
-        bottom: 100%;
-
-        text-align: center;
-        background-color: rgba(255, 255, 255, 0.5);
-        border-radius: $radius $radius 0 0;
-        font-size: 0.7rem;
-    }
-}
-
 #editor {
     position: absolute;
     // Height / width is applied to the element
@@ -527,12 +408,137 @@ $PHI: 2.61803398875;
     }
 }
 
+$header-tint: #428bca;
+$header-main-border: #dedede;
+$header-accent-border: #bdbdbd;
+$header-border-radius: 4px;
+$header-transition: 0.2s ease-in-out;
+
+.header {
+  display: flex;
+  font-size: 12px;
+
+  padding: 1.25em 0;
+
+  &__set {
+    margin-right: 0.5em;
+
+    &:last-child {
+      margin-right: 0;
+    }
+
+    &--channel-mode {
+      margin-right: auto;
+    }
+  }
+
+  button:enabled {
+    cursor: pointer;
+  }
+}
+
+@mixin button-reset {
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  line-height: inherit;
+  background: inherit;
+  background-color: transparent; // IE 11
+}
+
+@mixin active-button($bg-dark) {
+  background: linear-gradient($bg-dark, #ededed);
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.2);
+
+  border-top-color: #bababa;
+  border-bottom-color: #d6d6d6;
+}
+
+.segmented-button {
+  display: flex;
+  align-items: center;
+
+  border-radius: $header-border-radius;
+  box-shadow: 0 2px 4px -2px rgba(0, 0, 0, 0.4), inset 0 1px 0px white;
+
+  &__button {
+    @include button-reset;
+
+    $bg-light: #fff;
+    $bg-dark: #f9f9f9;
+
+    background-color: $bg-light;
+    background: linear-gradient($bg-light, $bg-dark);
+    color: #444;
+
+    border: 1px solid $header-main-border;
+
+    &:first-child {
+      border-top-left-radius: $header-border-radius;
+      border-bottom-left-radius: $header-border-radius;
+    }
+
+    &:last-child {
+      border-top-right-radius: $header-border-radius;
+      border-bottom-right-radius: $header-border-radius;
+    }
+
+    &:not(:first-child) {
+      border-left: none;
+    }
+
+    &:not(:last-child) {
+      border-right: 1px solid $header-main-border;
+    }
+
+    &:hover {
+      background: linear-gradient($bg-light, #f3f3f3);
+      color: #333;
+    }
+
+    &:active {
+      @include active-button($bg-dark);
+    }
+
+    &--build {
+      $rust-dark: #80331a;
+
+      background: $rust;
+      color: white;
+
+      border-color: hsl(15, 66.7%, 32%);
+
+      &:not(:last-child) {
+        // Silly specificity
+        border-right-width: 0;
+      }
+
+      .header-button {
+        font-weight: 700;
+      }
+
+      &:hover {
+        background: $rust-dark;
+        color: white;
+      }
+
+      &:active {
+        background: $rust-dark;
+        border-top-color: $rust-dark;
+        border-bottom-color: $rust-dark;
+      }
+    }
+  }
+}
+
 .popper {
   z-index: 10;
+  font-size: 12px;
 
   $fg-color: #222;
   $bg-color: white;
   $arrow-size: 10px;
+  $vertical-border-color: #cacaca;
 
   &__arrow {
     position: absolute;
@@ -549,8 +555,71 @@ $PHI: 2.61803398875;
   &__content {
     background: $bg-color;
     color: $fg-color;
-    border-radius: 2px;
-    box-shadow: 0 0 2px rgba(0, 0, 0, 0.5);
+
     margin: $arrow-size;
+
+    border-radius: $header-border-radius;
+
+    box-shadow: 0 1px 4px -2px rgba(0, 0, 0, 0.6), inset 0 1px 0px white;
+
+    border-left: 1px solid $vertical-border-color;
+    border-right: 1px solid $vertical-border-color;
+    border-bottom: 1px solid $header-accent-border;
   }
+
+  button:enabled {
+    cursor: pointer;
+  }
+}
+
+.header-button {
+  height: 3em;
+  padding: 0 1.25em;
+  display: flex;
+  align-items: center;
+
+  text-transform: uppercase;
+  text-decoration: none;
+  font-weight: 600;
+
+  white-space: nowrap;
+
+  &--expandable {
+    padding-right: 1em;
+  }
+
+  &--has-left-icon {
+    padding-left: 1em;
+  }
+
+  &--has-right-icon {
+    padding-right: 1em;
+  }
+
+  &--icon-only {
+    padding: 0 0.75em;
+  }
+
+  &__left-icon {
+    margin-right: 0.5em;
+    opacity: 0.5;
+  }
+
+  &--icon-only &__left-icon {
+    margin-right: 0;
+  }
+
+  &__drop {
+    margin-left: 0.75em;
+    opacity: 0.5;
+  }
+
+  &__right-icon {
+    margin-left: 0.75em;
+  }
+}
+
+.icon {
+  display: block;
+  fill: currentColor;
 }

--- a/ui/frontend/index.scss
+++ b/ui/frontend/index.scss
@@ -572,6 +572,70 @@ $header-transition: 0.2s ease-in-out;
   }
 }
 
+.menu-group {
+  width: 27em;
+  padding: 0.75em 1em 0 1em;
+
+  &:last-child {
+    padding-bottom: 0.75em;
+  }
+
+  line-height: normal;
+
+  &__title {
+    margin: 0;
+
+    text-transform: uppercase;
+    font-weight: 700;
+    font-size: 11px;
+    padding-bottom: 10px;
+    border-bottom: 1px solid $header-main-border;
+  }
+
+  &__content {
+    padding: 1em 0.25em;
+  }
+}
+
+.menu-item {
+  margin-bottom: 1em;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+}
+
+@mixin menu-item-title {
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.button-menu-item {
+  @include button-reset;
+
+  transition: color $header-transition;
+
+  &:hover {
+    color: $header-tint;
+  }
+
+  &__name {
+    @include menu-item-title;
+    margin: 0;
+  }
+
+  &__description {
+    margin: 0;
+  }
+}
+
+.build-menu {
+  &__aside {
+    margin: 0.25em 0 0 0;
+    color: #888;
+  }
+}
+
 .header-button {
   height: 3em;
   padding: 0 1.25em;

--- a/ui/frontend/index.scss
+++ b/ui/frontend/index.scss
@@ -629,6 +629,53 @@ $header-transition: 0.2s ease-in-out;
   }
 }
 
+// TODO: add 'menu'?
+.selectable-item {
+  width: 100%;
+  @include button-reset;
+
+  transition: color $header-transition;
+
+  &__header {
+    display: flex;
+    align-items: center;
+  }
+
+  &__name {
+    @include menu-item-title;
+  }
+
+  &__description {
+    padding-left: 2em;
+  }
+
+  &:hover {
+    color: $header-tint;
+  }
+
+  &--selected {
+    font-weight: 600;
+    color: $header-tint;
+  }
+
+  &__checkmark {
+    margin-right: 0.5em;
+
+    opacity: 0;
+    transition: opacity 0.15s ease-in-out;
+  }
+
+  &:hover &__checkmark {
+    opacity: 0.5;
+    color: $header-tint;
+  }
+
+  &--selected &__checkmark,
+  &--selected:hover &__checkmark {
+    opacity: 1;
+  }
+}
+
 .build-menu {
   &__aside {
     margin: 0.25em 0 0 0;

--- a/ui/frontend/package.json
+++ b/ui/frontend/package.json
@@ -16,6 +16,8 @@
     "react": "^16.0.0",
     "react-ace": "^5.4.0",
     "react-dom": "^16.0.0",
+    "react-popper": "^0.9.5",
+    "react-portal": "^4.1.4",
     "react-prism": "^4.0.0",
     "react-redux": "^5.0.0",
     "redux": "^3.5.2",

--- a/ui/frontend/selectors/index.ts
+++ b/ui/frontend/selectors/index.ts
@@ -13,6 +13,12 @@ const CRATE_TYPE_RE = /^\s*#!\s*\[\s*crate_type\s*=\s*"([^"]*)"\s*]/m;
 const getCrateTypeRaw = code => (code.match(CRATE_TYPE_RE) || [null, 'bin'])[1];
 export const getCrateType = createSelector([getCode], getCrateTypeRaw);
 
+export const getExecutionLabel = createSelector([runAsTest, getCrateType], (tests, crateType) => {
+  if (tests) { return 'Test'; }
+  if (crateType === 'bin') { return 'Run'; }
+  return 'Build';
+});
+
 const getStable = (state: State) => state.versions && state.versions.stable;
 const getBeta = (state: State) => state.versions && state.versions.beta;
 const getNightly = (state: State) => state.versions && state.versions.nightly;
@@ -26,3 +32,13 @@ export const nightlyVersionText = createSelector([getNightly], nonStable);
 export const isWasmAvailable = (state: State) => (
   state.configuration.channel === Channel.Nightly
 );
+
+export const getModeLabel = (state: State) => {
+  const { configuration: { mode } } = state;
+  return `${mode}`;
+};
+
+export const getChannelLabel = (state: State) => {
+  const { configuration: { channel } } = state;
+  return `${channel}`;
+};

--- a/ui/frontend/selectors/index.ts
+++ b/ui/frontend/selectors/index.ts
@@ -23,11 +23,14 @@ const getStable = (state: State) => state.versions && state.versions.stable;
 const getBeta = (state: State) => state.versions && state.versions.beta;
 const getNightly = (state: State) => state.versions && state.versions.nightly;
 
-export const stableVersionText = createSelector([getStable], v => v ? v.version : '');
+const versionNumber = v => v ? v.version : '';
+export const stableVersionText = createSelector([getStable], versionNumber);
+export const betaVersionText = createSelector([getBeta], versionNumber);
+export const nightlyVersionText = createSelector([getNightly], versionNumber);
 
-const nonStable = v => v ? `${v.version} (${v.date} ${v.hash})` : '';
-export const betaVersionText = createSelector([getBeta], nonStable);
-export const nightlyVersionText = createSelector([getNightly], nonStable);
+const versionDetails = v => v ? `${v.date} ${v.hash.slice(0, 20)}` : '';
+export const betaVersionDetailsText = createSelector([getBeta], versionDetails);
+export const nightlyVersionDetailsText = createSelector([getNightly], versionDetails);
 
 export const isWasmAvailable = (state: State) => (
   state.configuration.channel === Channel.Nightly

--- a/ui/frontend/tslint.json
+++ b/ui/frontend/tslint.json
@@ -10,6 +10,8 @@
     "interface-name": [true, "never-prefix"],
     "jsx-alignment": false,
     "jsx-no-lambda": false,
+    "jsx-no-multiline-js": false,
+    "jsx-boolean-value": [true, "never"],
     "max-classes-per-file": false,
     "member-ordering": false,
     "no-shadowed-variable": false,

--- a/ui/frontend/uss-router/Link.tsx
+++ b/ui/frontend/uss-router/Link.tsx
@@ -32,7 +32,9 @@ class Link extends React.Component<LinkProps> {
   };
 }
 
-interface LinkProps extends React.HTMLAttributes<HTMLAnchorElement> {
+type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
+
+export interface LinkProps extends Omit<React.HTMLProps<HTMLAnchorElement>, 'action'> {
   dispatch: (_: any) => any;
   action?: () => any;
   onClick?: () => any;

--- a/ui/frontend/yarn.lock
+++ b/ui/frontend/yarn.lock
@@ -4519,6 +4519,10 @@ pkg-dir@^2.0.0:
   dependencies:
     find-up "^2.1.0"
 
+popper.js@^1.14.1:
+  version "1.14.3"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.14.3.tgz#1438f98d046acf7b4d78cd502bf418ac64d4f095"
+
 posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
@@ -4856,7 +4860,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.0:
+prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1:
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
   dependencies:
@@ -4994,6 +4998,19 @@ react-dom@^16.0.0:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.0"
+
+react-popper@^0.9.5:
+  version "0.9.5"
+  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-0.9.5.tgz#02a24ef3eec33af9e54e8358ab70eb0e331edd05"
+  dependencies:
+    popper.js "^1.14.1"
+    prop-types "^15.6.1"
+
+react-portal@^4.1.4:
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/react-portal/-/react-portal-4.1.4.tgz#3fc3f3f3a0e81362ab1dc9afa3c4bb5a84ec76a3"
+  dependencies:
+    prop-types "^15.5.8"
 
 react-prism@^4.0.0:
   version "4.3.2"


### PR DESCRIPTION
This design from @lqd reduces the visual clutter of the playground's header, allowing new users to quickly identify important aspects and improving fit on smaller screen sizes. 

before:

![image](https://user-images.githubusercontent.com/174509/39070775-a2276a0e-44b2-11e8-91f6-a575a23880de.png)

after:

![image](https://user-images.githubusercontent.com/174509/39070784-a9cedc92-44b2-11e8-805a-d6e3dfcd5eaf.png)

We also now have the ability to provide a bit of descriptive text about each option:

![image](https://user-images.githubusercontent.com/174509/39070826-db79588a-44b2-11e8-985f-90a968dc07c9.png)

Some [pre-release feedback](https://users.rust-lang.org/t/playground-ui-prototype-feedback/16692/13) was gathered from users. 