### PR TITLE
Restore scrolling of the help page

### DIFF
--- a/ui/frontend/index.scss
+++ b/ui/frontend/index.scss
@@ -29,7 +29,6 @@ body {
     background-color: $background;
     padding: 0 1em;
     font-family: $primary-font;
-    overflow-y: hidden;
 }
 
 @mixin split-first-child() {
@@ -534,6 +533,11 @@ $header-transition: 0.2s ease-in-out;
 .popper {
   z-index: 10;
   font-size: 12px;
+
+  // Prevents the popper from shifting when adding it to the DOM
+  // triggers showing the scrollbars.
+  // https://github.com/FezVrasta/popper.js/issues/457#issuecomment-367692177
+  top: 0;
 
   $fg-color: #222;
   $bg-color: white;


### PR DESCRIPTION
We are using React-Portal to add the Popper.js Poppers to the DOM. By
default, these are added at the end of the `<body>` tag. Since our
content takes up the entire page, adding them causes the scrollbars to
appear momentarily, which Popper.js uses in the calculations. When the
popper is moved to the right place, the scrollbar disappears, and the
popper has to move a second time.

We "fixed" this by disabling the scrollbars completely, forgetting
about the help page. This fixes it by positioning the popper so it
doesn't cause the scrollbars to appear to start with.

Closes #304