### PR TITLE
Switch Poppers to transform-less positioning

### DIFF
--- a/ui/frontend/PopButton.tsx
+++ b/ui/frontend/PopButton.tsx
@@ -51,7 +51,7 @@ interface PopButtonPopperProps {
 const PopButtonPopper: React.SFC<PopButtonPopperProps> = ({ setPopperRef, children }) => (
   <Portal>
     <div ref={setPopperRef}>
-      <Popper className="popper" placement="bottom">
+      <Popper className="popper" placement="bottom" modifiers={{ computeStyle: { gpuAcceleration: false } }}>
         <Arrow className="popper__arrow" />
         <div className="popper__content">{children}</div>
       </Popper>


### PR DESCRIPTION
The default GPU-accelerated transforms used for positioning made text rendering blurry in certain configurations of browsers and cleartype settings on Windows.

Fixes #303