### PR TITLE
Fix miri build process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,13 @@ before_install:
   - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
 
 jobs:
+  allow_failures:
+    - env:
+        - TOOLS_TO_BUILD="rustfmt"
+    - env:
+        - TOOLS_TO_BUILD="clippy"
+    - env:
+        - TOOLS_TO_BUILD="miri"
   include:
     - stage: build compiler containers
       env:
@@ -37,10 +44,10 @@ jobs:
       script: ./.travis/build-containers.sh
     - env:
         - TOOLS_TO_BUILD="clippy"
-      script: ./.travis/build-containers.sh || true
+      script: ./.travis/build-containers.sh
     - env:
         - TOOLS_TO_BUILD="miri"
-      script: ./.travis/build-containers.sh || true
+      script: ./.travis/build-containers.sh
 
     - stage: compile code
       env:

--- a/compiler/miri/Dockerfile
+++ b/compiler/miri/Dockerfile
@@ -6,6 +6,7 @@ FROM sources as build
 
 RUN cargo install xargo
 RUN git clone https://github.com/solson/miri ~/miri
+RUN rm -f ~/miri/rust-toolchain # make sure we use our toolchain
 RUN ~/miri/xargo/build.sh
 RUN cargo install --all-features --path ~/miri
 


### PR DESCRIPTION
However, I am not sure if I got that travis syntax right and their validator is deprecated without replacement... I guess we'll see in the PR's travis run?

Fixes https://github.com/integer32llc/rust-playground/issues/387