### PR TITLE
Combine metadata requests

### DIFF
--- a/ui/frontend/index.tsx
+++ b/ui/frontend/index.tsx
@@ -8,7 +8,7 @@ import persistState from 'redux-localstorage';
 import thunk, { ThunkDispatch } from 'redux-thunk';
 import * as url from 'url';
 
-import { Action, gotoPosition, performCratesLoad, performVersionsLoad, reExecuteWithBacktrace } from './actions';
+import { Action, gotoPosition, performMetadataLoad, reExecuteWithBacktrace } from './actions';
 import { configureRustErrors } from './highlighting';
 import { deserialize, serialize } from './local_storage';
 import PageSwitcher from './PageSwitcher';
@@ -35,8 +35,7 @@ configureRustErrors({
   getChannel: () => store.getState().configuration.channel,
 });
 
-store.dispatch(performCratesLoad());
-store.dispatch(performVersionsLoad());
+store.dispatch(performMetadataLoad());
 
 ReactDOM.render(
   <Provider store={store}>


### PR DESCRIPTION
The playground currently starts 7 requests concurrently when first loading.
Since most browsers only allow 6 concurrent connections per domain by defaut,
the last one would likely block.  In addition, the total size of responses
will decrease because there is only one set of response headers.