### PR TITLE
Feature: copying embedded code link

### DIFF
--- a/ui/frontend/Output/Gist.tsx
+++ b/ui/frontend/Output/Gist.tsx
@@ -4,11 +4,18 @@ import { connect } from 'react-redux';
 
 import { ClipboardIcon } from '../Icon';
 import { State } from '../reducers';
-import { issueUrlSelector, permalinkSelector, showGistLoaderSelector, urloUrlSelector } from '../selectors';
+import {
+  codeUrlSelector,
+  issueUrlSelector,
+  permalinkSelector,
+  showGistLoaderSelector,
+  urloUrlSelector,
+} from '../selectors';
 
 import Loader from './Loader';
 
 interface GistProps {
+  codeUrl?: string;
   gistUrl?: string;
   issueUrl?: string;
   permalink?: string;
@@ -26,6 +33,7 @@ const Links: React.SFC<GistProps> = props => (
   <Fragment>
     <Copied href={props.permalink}>Permalink to the playground</Copied>
     <Copied href={props.gistUrl}>Direct link to the gist</Copied>
+    <Copied href={props.codeUrl}>Embedded code in link</Copied>
     <p><a href={props.urloUrl} target="_blank">Open a new thread in the Rust user forum</a></p>
     <p><a href={props.issueUrl} target="_blank"> Open an issue on the Rust GitHub repository </a></p>
   </Fragment>
@@ -66,6 +74,7 @@ class Copied extends React.PureComponent<CopiedProps, CopiedState> {
 }
 
 const mapStateToProps = (state: State) => ({
+  codeUrl: codeUrlSelector(state),
   gistUrl: state.output.gist.url,
   issueUrl: issueUrlSelector(state),
   permalink: permalinkSelector(state),

--- a/ui/frontend/selectors/index.ts
+++ b/ui/frontend/selectors/index.ts
@@ -162,21 +162,26 @@ const baseUrlSelector = (state: State) =>
 const gistSelector = (state: State) =>
   state.output.gist;
 
+// Selects url.query of build configs.
+const urlQuerySelector = createSelector(
+  gistSelector,
+  gist => ({
+    version: gist.channel,
+    mode: gist.mode,
+    edition: gist.edition,
+  }),
+);
+
 export const showGistLoaderSelector = createSelector(
   gistSelector,
   gist => gist.requestsInProgress > 0,
 );
 
 export const permalinkSelector = createSelector(
-  baseUrlSelector, gistSelector,
-  (baseUrl, gist) => {
+  baseUrlSelector, urlQuerySelector, gistSelector,
+  (baseUrl, query, gist) => {
     const u = url.parse(baseUrl, true);
-    u.query = {
-      gist: gist.id,
-      version: gist.channel,
-      mode: gist.mode,
-      edition: gist.edition,
-    };
+    u.query = { ...query, gist: gist.id };
     return url.format(u);
   },
 );
@@ -238,6 +243,15 @@ export const issueUrlSelector = createSelector(
     const newIssueUrl = url.parse('https://github.com/rust-lang/rust/issues/new', true);
     newIssueUrl.query = { body: snippet };
     return url.format(newIssueUrl);
+  },
+);
+
+export const codeUrlSelector = createSelector(
+  baseUrlSelector, urlQuerySelector, gistSelector,
+  (baseUrl, query, gist) => {
+    const u = url.parse(baseUrl, true);
+    u.query = { ...query, code: gist.code };
+    return url.format(u);
   },
 );
 


### PR DESCRIPTION
Hey maintainers, this is my first contribution to rust-playground. If I did something inappropriate or violating any rule, just tell me directly. Thanks.

## Goal

`code` querystring is an awesome feature to share code instantly without generating additional gist. Hence, I implemented a proof of concept that copying URL with `code` query. Currently, this feature is placed in **Gist.tsx** component behind the **SHARE** button. If you consider this helpful, I am willing to complete it in an independent UI without creating any gist.

## Steps To Test

1. Click SHARE button
2. Click copy icon right after **Embedded code in link**.



## Caveats

Although some browsers may set a maximum length limit on their URL location bar, it seems that Firefox and Chrome support at least 10k lines of code. Here are screenshots of my manual tests on Firefox nightly 64.0a1.

1. generate 10k lines of code ![1](https://user-images.githubusercontent.com/14314532/46710513-c354ef80-cc7a-11e8-9c52-87346fdc3895.gif)

2. open URL with 10k lines embedded ![2](https://user-images.githubusercontent.com/14314532/46710514-c354ef80-cc7a-11e8-968b-5417385135c0.gif)



