### PR TITLE
Click help hint link to enable feature gate

### DIFF
--- a/ui/frontend/actions.ts
+++ b/ui/frontend/actions.ts
@@ -81,6 +81,7 @@ export enum ActionType {
   CompileWasmFailed = 'COMPILE_WASM_FAILED',
   EditCode = 'EDIT_CODE',
   AddMainFunction = 'ADD_MAIN_FUNCTION',
+  EnableFeatureGate = 'ENABLE_FEATURE_GATE',
   GotoPosition = 'GOTO_POSITION',
   RequestFormat = 'REQUEST_FORMAT',
   FormatSucceeded = 'FORMAT_SUCCEEDED',
@@ -423,6 +424,9 @@ export const editCode = (code: string) =>
 export const addMainFunction = () =>
   createAction(ActionType.AddMainFunction);
 
+export const enableFeatureGate = (featureGate: string) =>
+  createAction(ActionType.EnableFeatureGate, { featureGate });
+
 export const gotoPosition = (line, column) =>
   createAction(ActionType.GotoPosition, { line: +line, column: +column });
 
@@ -737,6 +741,7 @@ export type Action =
   | ReturnType<typeof receiveCompileWasmFailure>
   | ReturnType<typeof editCode>
   | ReturnType<typeof addMainFunction>
+  | ReturnType<typeof enableFeatureGate>
   | ReturnType<typeof gotoPosition>
   | ReturnType<typeof requestFormat>
   | ReturnType<typeof receiveFormatSuccess>

--- a/ui/frontend/index.tsx
+++ b/ui/frontend/index.tsx
@@ -8,7 +8,14 @@ import persistState from 'redux-localstorage';
 import thunk, { ThunkDispatch } from 'redux-thunk';
 import * as url from 'url';
 
-import { Action, gotoPosition, performCratesLoad, performVersionsLoad, reExecuteWithBacktrace } from './actions';
+import {
+  Action,
+  enableFeatureGate,
+  gotoPosition,
+  performCratesLoad,
+  performVersionsLoad,
+  reExecuteWithBacktrace,
+} from './actions';
 import { configureRustErrors } from './highlighting';
 import { deserialize, serialize } from './local_storage';
 import PageSwitcher from './PageSwitcher';
@@ -30,6 +37,7 @@ const enhancers = composeEnhancers(middlewares, persistState(undefined, { serial
 const store = createStore(playgroundApp, initialState, enhancers);
 
 configureRustErrors({
+  enableFeatureGate: featureGate => store.dispatch(enableFeatureGate(featureGate)),
   gotoPosition: (line, col) => store.dispatch(gotoPosition(line, col)),
   reExecuteWithBacktrace: () => store.dispatch(reExecuteWithBacktrace()),
   getChannel: () => store.getState().configuration.channel,

--- a/ui/frontend/reducers/code.ts
+++ b/ui/frontend/reducers/code.ts
@@ -17,7 +17,10 @@ export default function code(state = DEFAULT, action: Action): State {
       return action.code;
 
     case ActionType.AddMainFunction:
-      return state + '\n\n' + DEFAULT;
+      return `${state}\n\n'${DEFAULT}`;
+
+    case ActionType.EnableFeatureGate:
+      return `#![feature(${action.featureGate})]\n${state}`;
 
     case ActionType.FormatSucceeded:
       return action.code;


### PR DESCRIPTION
close #317

## Goal

When error message contains help hint as below,

```
error[E0658]: non-ascii idents are not fully supported. (see issue #28979)
 --> src/main.rs:4:9
  |
4 |     let α = 0.00001f64; // #![feature(non_ascii_idents)]
  |         ^
  |
  = help: add #![feature(non_ascii_idents)] to the crate attributes to enable
```

Highlight `add #![feature(non_ascii_idents)]` and provide a clickable link to insert code at  the first line to enable corresponding feature gate.

## Result

Output standard error are highlighted as following image. It seems a bit dumb. Maybe click-to-add anchors need additional styling?

![screen shot 2018-10-11 at 03 49 30](https://user-images.githubusercontent.com/14314532/46762122-e201c780-cd08-11e8-92d0-969108bb2879.png)

## Tests

I cannot figure out how to bootstrap Ruby environment to run rspec. Therefore, this feature only be tested manually. Below is a valid test case.

```rust
const X: u8 = { let x = 1; x }; // #![feature(const_let)]

fn main() {
    let α = 0.00001f64; // #![feature(non_ascii_idents)]
}
```
