### PR TITLE
Remove typo single quote for adding main function

### DIFF
--- a/ui/frontend/reducers/code.ts
+++ b/ui/frontend/reducers/code.ts
@@ -17,7 +17,7 @@ export default function code(state = DEFAULT, action: Action): State {
       return action.code;
 
     case ActionType.AddMainFunction:
-      return `${state}\n\n'${DEFAULT}`;
+      return `${state}\n\n${DEFAULT}`;
 
     case ActionType.EnableFeatureGate:
       return `#![feature(${action.featureGate})]\n${state}`;


### PR DESCRIPTION
We changed from string concatenation to string interpolation in https://github.com/integer32llc/rust-playground/pull/415.

With using string interpolation, we don't need the single quote now and it will cause the `fn` to be `'fn`.

| As is | To be |
| ----- | ----- |
| <img width="326" alt="default" src="https://user-images.githubusercontent.com/6782666/46809772-cdbdd900-cda1-11e8-8f66-7140b9bba13d.png"> | <img width="317" alt="default" src="https://user-images.githubusercontent.com/6782666/46809814-e8904d80-cda1-11e8-80b9-e6662f65b1bc.png"> |

