### PR TITLE
-Zmiri-start-fn is gone

### DIFF
--- a/compiler/miri/cargo-miri-playground
+++ b/compiler/miri/cargo-miri-playground
@@ -3,4 +3,4 @@
 set -eu
 
 export MIRI_SYSROOT=~/.xargo/HOST
-exec cargo miri -- -Zmiri-start-fn
+exec cargo miri


### PR DESCRIPTION
With https://github.com/solson/miri/pull/488 merged, `-Zmiri-start-fn` no longer exists as a parameter.