### PR TITLE
update for miri's new automatic libstd build

### DIFF
--- a/compiler/miri/Dockerfile
+++ b/compiler/miri/Dockerfile
@@ -4,15 +4,12 @@ RUN rustup component add rust-src
 
 FROM sources as build
 
-RUN cargo install xargo
-RUN git clone https://github.com/solson/miri ~/miri
-RUN rm -f ~/miri/rust-toolchain # make sure we use our toolchain
-RUN ~/miri/xargo/build.sh
-RUN cargo install --all-features --path ~/miri
+RUN cargo install --git https://github.com/solson/miri/ miri
+RUN cargo miri setup
 
 FROM sources
 
-COPY --from=build /root/.xargo /root/.xargo
+COPY --from=build /root/.cache/miri /root/.cache/miri
 COPY --from=build /root/.cargo/bin/miri /root/.cargo/bin
 COPY --from=build /root/.cargo/bin/cargo-miri /root/.cargo/bin
 ADD cargo-miri-playground /root/.cargo/bin

--- a/compiler/miri/cargo-miri-playground
+++ b/compiler/miri/cargo-miri-playground
@@ -2,5 +2,5 @@
 
 set -eu
 
-export MIRI_SYSROOT=~/.xargo/HOST
+export MIRI_SYSROOT=~/.cache/miri/HOST
 exec cargo miri


### PR DESCRIPTION
`cargo miri` now automatically installs xargo and the rust-src component and builds libstd. `cargo miri setup` is a way to do only that, and without interactive questions.

When actually executing the file, we set the `MIRI_SYSROOT` env var manually. That is not needed, but it makes sure that the automatic setup part is skipped (it shouldn't do anything anyway).