### PR TITLE
Speeding up build/run requests with a pool of idle docker containers

### DIFF
--- a/compiler/base/Dockerfile
+++ b/compiler/base/Dockerfile
@@ -41,6 +41,7 @@ RUN cd / && \
 WORKDIR /playground
 
 ADD Cargo.toml /playground/Cargo.toml
+ADD cargo.sh /playground/cargo.sh
 ADD crate-information.json /playground/crate-information.json
 RUN cargo fetch
 

--- a/compiler/base/cargo.sh
+++ b/compiler/base/cargo.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -eu
+
+POSITIONAL=()
+
+while [[ $# -gt 0 ]]; do
+        case $1 in
+                --env)
+                        export $2
+                        shift 2
+                        ;;
+                *)
+                        POSITIONAL+=("$1")
+                        shift
+                        ;;
+        esac
+done
+
+eval set -- "${POSITIONAL[@]}"
+
+timeout=${PLAYGROUND_TIMEOUT:-10}
+
+modify-cargo-toml
+
+timeout --signal=KILL ${timeout} cargo "$@" || pkill sleep
+
+pkill sleep

--- a/compiler/base/entrypoint.sh
+++ b/compiler/base/entrypoint.sh
@@ -1,8 +1,3 @@
 #!/bin/bash
 
-set -eu
-
-timeout=${PLAYGROUND_TIMEOUT:-10}
-
-modify-cargo-toml
-timeout --signal=KILL ${timeout} "$@"
+sleep 365d

--- a/ui/Cargo.lock
+++ b/ui/Cargo.lock
@@ -205,6 +205,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "nix 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "dotenv"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -671,6 +680,18 @@ dependencies = [
  "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "nix"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1461,6 +1482,7 @@ version = "0.1.0"
 dependencies = [
  "bodyparser 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "corsware 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ctrlc 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "dotenv 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hubcaps 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1556,6 +1578,11 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "want"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1645,6 +1672,7 @@ dependencies = [
 "checksum crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c979cd6cfe72335896575c6b5688da489e420d36a27a0b9eb0c73db574b4a4b"
 "checksum crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f8306fcef4a7b563b76b7dd949ca48f52bc1141aa067d2ea09565f3e2652aa5c"
 "checksum csv 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7ef22b37c7a51c564a365892c012dc0271221fdcc64c69b19ba4d6fa8bd96d9c"
+"checksum ctrlc 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "630391922b1b893692c6334369ff528dcc3a9d8061ccf4c803aa8f83cb13db5e"
 "checksum dotenv 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0d0a1279c96732bc6800ce6337b6a614697b0e74ae058dc03c62ebeb78b4d86"
 "checksum env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b61fa891024a945da30a9581546e8cfaf5602c7b3f4c137a2805cf388f92075a"
 "checksum error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "07e791d3be96241c77c43846b665ef1384606da2cd2a48730abe606a12906e02"
@@ -1695,6 +1723,7 @@ dependencies = [
 "checksum mount 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e25c06012941aaf8c75f2eaf7ec5c48cf69f9fc489ab3eb3589edc107e386f0b"
 "checksum native-tls 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ff8e08de0070bbf4c31f452ea2a70db092f36f6f2e4d897adf5674477d488fb2"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
+"checksum nix 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d37e713a259ff641624b6cb20e3b12b2952313ba36b6823c0f16e6cfd9e5de17"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
 "checksum num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1a23f0ed30a54abaa0c7e83b1d2d87ada7c3c23078d1d87815af3e3b6385fbba"
 "checksum openssl 0.10.19 (registry+https://github.com/rust-lang/crates.io-index)" = "84321fb9004c3bce5611188a644d6171f895fa2889d155927d528782edb21c5d"
@@ -1794,6 +1823,7 @@ dependencies = [
 "checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"
 "checksum vcpkg 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "def296d3eb3b12371b2c7d0e83bfe1403e4db2d7a0bba324a12b21c4ee13143d"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
+"checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum want 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "797464475f30ddb8830cc529aaaae648d581f99e2036a928877dfde027ddf6b3"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -32,6 +32,7 @@ router = "0.6.0"
 openssl-probe = "0.1.2"
 dotenv = "0.13.0"
 snafu = "0.2.0"
+ctrlc = { version = "3.1.1", features = ["termination"] }
 
 [dependencies.playground-middleware]
 git = "https://github.com/integer32llc/playground-middleware"


### PR DESCRIPTION
This is a possible solution to #457 

I've sped up the compilation/execution of snippets by using previously started and idle docker containers, rather than starting a new one for each request.
On my dev box, this new version runs a "hello world" in ~600 ms, while the master version takes ~1.3 secs. Since `rustc` takes ~400 ms, the overhead of docker is reduced to ~200 ms per request.

**How it works**
A pool of idle docker containers is started at playground start up. The default size is 10 containers per channel.
By sleeping for a long time in `entrypoint.sh`, containers stay idle.
When a request is handled, a container is removed from the pool. Cargo is called through `cargo.sh`, which cares of exporting env vars and killing the container once it's done. Thus, there's no need to drop a container that has been used.
However idle containers in the pool need to me manually terminated: DockerContainers `Drop` impl takes care of that, and kills them in parallel.
To ensure that `drop` is called when server shuts down, I've used crate `ctrlc` to install a shutdown hook

**Known issues**
Benchmarking the `/execute` api with `siege`, the new *pool* version is slightly slower than the master one: the former replies to ~4.5 req/sec, the latter to ~5.5 req/s
Also, because there's no way to gracefully shutdown iron (see https://github.com/hyperium/hyper/issues/338), if the server is terminated while receiving lots of requests, there's a chance that some docker containers will survive the shutdown: they'll have to be manually terminated.

On a side note, I'm new to rust, so any feedback is welcome