### PR TITLE
pass a seed to Miri so that HashMaps work

### DIFF
--- a/compiler/miri/cargo-miri-playground
+++ b/compiler/miri/cargo-miri-playground
@@ -3,4 +3,4 @@
 set -eu
 
 export MIRI_SYSROOT=~/.cache/miri/HOST
-exec cargo miri
+exec cargo miri -- -Zmiri-seed=cafedead


### PR DESCRIPTION
Miri now supports system-seeded RNGs but simulates them with a fixed seed that needs to be passed on the command-line.