### PR TITLE
Prevent the cursor from jumping to the end of the file

### DIFF
--- a/ui/frontend/AdvancedEditor.tsx
+++ b/ui/frontend/AdvancedEditor.tsx
@@ -146,8 +146,9 @@ const AdvancedEditor: React.SFC<AdvancedEditorProps> = props => {
   useEditorProp(props.code, (editor, code) => {
     if (editor.getValue() !== code) {
       silenceOnChange.current = true;
+      const currentSelection = editor.selection.toJSON();
       editor.setValue(code);
-      editor.selection.clearSelection();
+      editor.selection.fromJSON(currentSelection);
       silenceOnChange.current = false;
     }
   });

--- a/ui/frontend/types/ace-builds.ts
+++ b/ui/frontend/types/ace-builds.ts
@@ -66,5 +66,21 @@ declare module 'ace-builds' {
     export interface Editor {
       execCommand(name: string | string[], args?: any): any;
     }
+
+    // Allows preserving and restoring the selection across an external update
+    //
+    // const currentSelection = editor.selection.toJSON();
+    // editor.setValue(code, 1);
+    // editor.selection.fromJSON(currentSelection);
+    interface SavedSelection {
+      start: Point;
+      end: Point;
+      isBackwards: boolean;
+    }
+
+    export interface Selection {
+      toJSON(): SavedSelection;
+      fromJSON(selection: SavedSelection): void;
+    }
   }
 }


### PR DESCRIPTION
We need to preserve our current selection state when Redux drives the
update. It would be good to figure out *why* this update is occurring
though...

Closes #494