### PR TITLE
Remove trailing whitespace for multiple gist embed

### DIFF
--- a/ui/src/gist.rs
+++ b/ui/src/gist.rs
@@ -31,7 +31,7 @@ impl From<gists::Gist> for Gist {
             _ => {
                 files
                     .into_iter()
-                    .map(|(name, content)| format!("// {}\n\n{}\n\n", name, content))
+                    .map(|(name, content)| format!("// {}\n{}\n\n", name, content))
                     .collect()
             }
         };


### PR DESCRIPTION
When multiple gist is imported, there is a trailing whitespace between the comment representing filename and the code, giving a sense of disjointedness:
```
// Imlementation.rs

fn greet(s: &String) -> String {
  format!("Hello {name}!", name=s)
}
```

Here is a live demo:
https://play.rust-lang.org/?gist=1f059252234606216cf8721209456287&version=stable

This commit removes the trailing whitespace after the filename.