### PR TITLE
Fix highlight for warnings with error number

### DIFF
--- a/ui/frontend/highlighting.ts
+++ b/ui/frontend/highlighting.ts
@@ -7,7 +7,13 @@ export function configureRustErrors({
   reExecuteWithBacktrace,
 }) {
   Prism.languages.rust_errors = { // eslint-disable-line camelcase
-    'warning': /^warning:.*$/m,
+    'warning': {
+      pattern: /^warning(\[E\d+\])?:.*$/m,
+      inside: {
+        'error-explanation': /\[E\d+\]/,
+        'see-issue': /see issue #\d+/,
+      },
+    },
     'error': {
       pattern: /^error(\[E\d+\])?:.*$/m,
       inside: {


### PR DESCRIPTION
Fix #505

| Before | After |
| ------- | ----- |
| ![image](https://user-images.githubusercontent.com/6782666/60859513-f221e580-a24d-11e9-9f5c-f523bfe0f743.png) | ![image](https://user-images.githubusercontent.com/6782666/60859518-f948f380-a24d-11e9-98b8-6ba829f4f4ff.png) |

