### PR TITLE
Upgrade lodash to 4.17.13

### DIFF
--- a/ui/frontend/package.json
+++ b/ui/frontend/package.json
@@ -10,7 +10,7 @@
     "core-js": "^3.1.3",
     "history": "^4.6.0",
     "isomorphic-fetch": "^2.2.1",
-    "lodash": "^4.17.0",
+    "lodash": "^4.17.13",
     "prismjs": "^1.6.0",
     "prop-types": "^15.5.10",
     "qs": "^6.4.0",

--- a/ui/frontend/yarn.lock
+++ b/ui/frontend/yarn.lock
@@ -4362,10 +4362,10 @@ lodash.tail@^4.1.1:
   resolved "https://registry.yarnpkg.com/lodash.tail/-/lodash.tail-4.1.1.tgz#d2333a36d9e7717c8ad2f7cacafec7c32b444664"
   integrity sha1-0jM6NtnncXyK0vfKyv7HwytERmQ=
 
-lodash@^4.0.0, lodash@^4.17.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.3, lodash@^4.17.4, lodash@~4.17.10:
-  version "4.17.11"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
-  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
+lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.3, lodash@^4.17.4, lodash@~4.17.10:
+  version "4.17.13"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.13.tgz#0bdc3a6adc873d2f4e0c4bac285df91b64fc7b93"
+  integrity sha512-vm3/XWXfWtRua0FkUyEHBZy8kCPjErNBT9fJx8Zvs+U6zjqPbTUOpkaoum3O5uiA8sm+yNMHXfYkTUHFoMxFNA==
 
 loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
There's [a security vulnerability](https://snyk.io/blog/snyk-research-team-discovers-severe-prototype-pollution-security-vulnerabilities-affecting-all-versions-of-lodash/) reported by Snyk about lodash. We can fix it by upgrading to `4.17.13` (https://github.com/lodash/lodash/issues/4348#issuecomment-509716822)!