### PR TITLE
miri no longer needs -Zmiri-seed

### DIFF
--- a/compiler/miri/cargo-miri-playground
+++ b/compiler/miri/cargo-miri-playground
@@ -3,4 +3,4 @@
 set -eu
 
 export MIRI_SYSROOT=~/.cache/miri/HOST
-exec cargo miri -- -Zmiri-seed=cafedead
+exec cargo miri


### PR DESCRIPTION
With https://github.com/rust-lang/miri/pull/851, this is the default.