### PR TITLE
Allow selecting the menu button's text

### DIFF
--- a/ui/frontend/index.scss
+++ b/ui/frontend/index.scss
@@ -644,6 +644,7 @@ $header-transition: 0.2s ease-in-out;
 
   width: 100%;
   transition: color $header-transition;
+  user-select: text;
 }
 
 .button-menu-item {


### PR DESCRIPTION
You still have to start the drag from off of the button, but it's
better.