### PR TITLE
Add support for async main function

### DIFF
--- a/ui/frontend/selectors/index.spec.ts
+++ b/ui/frontend/selectors/index.spec.ts
@@ -21,12 +21,20 @@ describe('checking for a main function', () => {
     expect(hasMainFunctionSelector(buildState('pub fn main()'))).toBe(true);
   });
 
+  test('an async main counts', () => {
+    expect(hasMainFunctionSelector(buildState('async fn main()'))).toBe(true);
+  });
+
+  test('a public async main counts', () => {
+    expect(hasMainFunctionSelector(buildState('pub async fn main()'))).toBe(true);
+  });
+
   test('leading indentation is ignored', () => {
     expect(hasMainFunctionSelector(buildState('\t fn main()'))).toBe(true);
   });
 
   test('extra space everywhere is ignored', () => {
-    expect(hasMainFunctionSelector(buildState('  pub  fn  main  (  )'))).toBe(true);
+    expect(hasMainFunctionSelector(buildState('  pub async   fn  main  (  )'))).toBe(true);
   });
 
   test('a commented-out main does not count', () => {

--- a/ui/frontend/selectors/index.ts
+++ b/ui/frontend/selectors/index.ts
@@ -10,7 +10,7 @@ const codeSelector = (state: State) => state.code;
 const HAS_TESTS_RE = /^\s*#\s*\[\s*test\s*([^"]*)]/m;
 export const hasTestsSelector = createSelector(codeSelector, code => !!code.match(HAS_TESTS_RE));
 
-const HAS_MAIN_FUNCTION_RE = /^\s*(pub\s+)?fn\s+main\s*\(\s*\)/m;
+const HAS_MAIN_FUNCTION_RE = /^\s*(pub\s+)?\s*(async\s+)?\s*fn\s+main\s*\(\s*\)/m;
 export const hasMainFunctionSelector = createSelector(codeSelector, code => !!code.match(HAS_MAIN_FUNCTION_RE));
 
 const CRATE_TYPE_RE = /^\s*#!\s*\[\s*crate_type\s*=\s*"([^"]*)"\s*]/m;


### PR DESCRIPTION
This adds support for an `async main` function. It updates the regex and tests per #563. It does not check for `#[tokio::main]` or another macro to see if its a properly configured `main` function.

I have not tried running the tests but it seems like they should pass.