### PR TITLE
Add ndarry-rand package

### DIFF
--- a/compiler/base/Cargo.toml
+++ b/compiler/base/Cargo.toml
@@ -503,6 +503,10 @@ version = "=0.2.3"
 package = "ndarray"
 version = "=0.13.0"
 
+[dependencies.ndarray_rand]
+package = "ndarray-rand"
+version = "=0.11.0"
+
 [dependencies.net2]
 package = "net2"
 version = "=0.2.33"

--- a/compiler/base/crate-information.json
+++ b/compiler/base/crate-information.json
@@ -605,6 +605,11 @@
     "id": "ndarray"
   },
   {
+    "name": "ndarray-rand",
+    "version": "0.11.0",
+    "id": "ndarray_rand"
+  },
+  {
     "name": "net2",
     "version": "0.2.33",
     "id": "net2"


### PR DESCRIPTION
In order to test ndarry conveniently, can we add this `ndarry-rand` lib in the play ground as well? It would be nice to be able to create some random arrays easily :)

For example, I would like to test and run example like this in the playground:
```rust
use ndarray::prelude::*;
use ndarray::Array;
use ndarray_rand::RandomExt;
use ndarray_rand::rand_distr::Uniform;

fn main() {
    let a = Array::random((2, 5), Uniform::new(0., 10.));
    println!("{:8.4}", a);
}
```