### PR TITLE
Add once_cell to crates available in playground

### DIFF
--- a/compiler/base/Cargo.toml
+++ b/compiler/base/Cargo.toml
@@ -551,6 +551,10 @@ version = "=0.2.3"
 package = "num-traits"
 version = "=0.2.11"
 
+[dependencies.once_cell]
+package = "once_cell"
+version = "=1.3.1"
+
 [dependencies.opaque_debug]
 package = "opaque-debug"
 version = "=0.2.3"

--- a/compiler/base/crate-information.json
+++ b/compiler/base/crate-information.json
@@ -670,6 +670,11 @@
     "id": "num_cpus"
   },
   {
+    "name": "once_cell",
+    "version": "1.3.1",
+    "id": "once_cell",
+  },
+  {
     "name": "opaque-debug",
     "version": "0.2.3",
     "id": "opaque_debug"


### PR DESCRIPTION
The `once_cell` crate is super useful to play around with so it would be useful to have this in the playground :)

Please let me know if I did this right! I added once_cell by hand to both the `Cargo.toml` and to `crate-information.json`.