### PR TITLE
Make import suggestions clickable

### DIFF
--- a/tests/Gemfile.lock
+++ b/tests/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
-    capybara (3.31.0)
+    capybara (3.32.0)
       addressable
       mini_mime (>= 0.1.3)
       nokogiri (~> 1.8)

--- a/tests/spec/features/assistance_spec.rb
+++ b/tests/spec/features/assistance_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+require 'support/editor'
+
+RSpec.feature "Editor assistance for common code modifications", type: :feature, js: true do
+  before { visit '/' }
+
+  scenario "building code without a main method offers adding one" do
+    editor.set <<~EOF
+      fn example() {}
+    EOF
+    click_on("Build")
+
+    within('.output-warning') do
+      click_on("add a main function")
+    end
+
+    within('.editor') do
+      expect(editor).to have_line 'println!("Hello, world!")'
+    end
+  end
+
+  private
+
+  def editor
+    Editor.new(page)
+  end
+end

--- a/tests/spec/features/assistance_spec.rb
+++ b/tests/spec/features/assistance_spec.rb
@@ -38,6 +38,21 @@ RSpec.feature "Editor assistance for common code modifications", type: :feature,
     end
   end
 
+  scenario "using a type that hasn't been imported offers importing it" do
+    editor.set <<~EOF
+      fn example(_: HashMap) {}
+    EOF
+    click_on("Build")
+
+    within('.output-stderr') do
+      click_on("use std::collections::HashMap;")
+    end
+
+    within('.editor') do
+      expect(editor).to have_line 'use std::collections::HashMap;'
+    end
+  end
+
   private
 
   def editor

--- a/tests/spec/features/assistance_spec.rb
+++ b/tests/spec/features/assistance_spec.rb
@@ -53,6 +53,23 @@ RSpec.feature "Editor assistance for common code modifications", type: :feature,
     end
   end
 
+  scenario "triggering a panic offers enabling backtraces" do
+    editor.set <<~EOF
+      fn main() {
+          panic!("Oops");
+      }
+    EOF
+    click_on("Run")
+
+    within('.output-stderr') do
+      click_on("run with `RUST_BACKTRACE=1` environment variable to display a backtrace")
+    end
+
+    within('.output-stderr') do
+      expect(page).to have_content("stack backtrace:")
+    end
+  end
+
   private
 
   def editor

--- a/tests/spec/features/assistance_spec.rb
+++ b/tests/spec/features/assistance_spec.rb
@@ -1,7 +1,10 @@
 require 'spec_helper'
 require 'support/editor'
+require 'support/playground_actions'
 
 RSpec.feature "Editor assistance for common code modifications", type: :feature, js: true do
+  include PlaygroundActions
+
   before { visit '/' }
 
   scenario "building code without a main method offers adding one" do
@@ -16,6 +19,22 @@ RSpec.feature "Editor assistance for common code modifications", type: :feature,
 
     within('.editor') do
       expect(editor).to have_line 'println!("Hello, world!")'
+    end
+  end
+
+  scenario "using an unstable feature offers adding the feature flag" do
+    in_channel_menu { click_on("Nightly") }
+    editor.set <<~EOF
+      fn foo<const T: usize>() {}
+    EOF
+    click_on("Build")
+
+    within('.output-stderr') do
+      click_on("add `#![feature(const_generics)]`")
+    end
+
+    within('.editor') do
+      expect(editor).to have_line '#![feature(const_generics)]'
     end
   end
 

--- a/ui/frontend/actions.ts
+++ b/ui/frontend/actions.ts
@@ -88,6 +88,7 @@ export enum ActionType {
   CompileWasmFailed = 'COMPILE_WASM_FAILED',
   EditCode = 'EDIT_CODE',
   AddMainFunction = 'ADD_MAIN_FUNCTION',
+  AddImport = 'ADD_IMPORT',
   EnableFeatureGate = 'ENABLE_FEATURE_GATE',
   GotoPosition = 'GOTO_POSITION',
   RequestFormat = 'REQUEST_FORMAT',
@@ -417,6 +418,9 @@ export const editCode = (code: string) =>
 
 export const addMainFunction = () =>
   createAction(ActionType.AddMainFunction);
+
+export const addImport = (code: string) =>
+  createAction(ActionType.AddImport, { code });
 
 export const enableFeatureGate = (featureGate: string) =>
   createAction(ActionType.EnableFeatureGate, { featureGate });
@@ -751,6 +755,7 @@ export type Action =
   | ReturnType<typeof receiveCompileWasmFailure>
   | ReturnType<typeof editCode>
   | ReturnType<typeof addMainFunction>
+  | ReturnType<typeof addImport>
   | ReturnType<typeof enableFeatureGate>
   | ReturnType<typeof gotoPosition>
   | ReturnType<typeof requestFormat>

--- a/ui/frontend/highlighting.ts
+++ b/ui/frontend/highlighting.ts
@@ -29,7 +29,7 @@ export function configureRustErrors({
     'rust-errors-help': {
       pattern: /help:.*\n/,
       inside: {
-        'feature-gate': /add #\!\[feature\(.+?\)\]/,
+        'feature-gate': /add `#\!\[feature\(.+?\)\]`/,
       },
     },
     'backtrace': {

--- a/ui/frontend/index.tsx
+++ b/ui/frontend/index.tsx
@@ -14,6 +14,7 @@ import {
   editCode,
   enableFeatureGate,
   gotoPosition,
+  addImport,
   performCratesLoad,
   performVersionsLoad,
   reExecuteWithBacktrace,
@@ -48,6 +49,7 @@ const store = createStore(playgroundApp, initialState, enhancers);
 configureRustErrors({
   enableFeatureGate: featureGate => store.dispatch(enableFeatureGate(featureGate)),
   gotoPosition: (line, col) => store.dispatch(gotoPosition(line, col)),
+  addImport: (code) => store.dispatch(addImport(code)),
   reExecuteWithBacktrace: () => store.dispatch(reExecuteWithBacktrace()),
   getChannel: () => store.getState().configuration.channel,
 });

--- a/ui/frontend/reducers/code.ts
+++ b/ui/frontend/reducers/code.ts
@@ -19,6 +19,9 @@ export default function code(state = DEFAULT, action: Action): State {
     case ActionType.AddMainFunction:
       return `${state}\n\n${DEFAULT}`;
 
+    case ActionType.AddImport:
+      return action.code + state;
+
     case ActionType.EnableFeatureGate:
       return `#![feature(${action.featureGate})]\n${state}`;
 


### PR DESCRIPTION
In this PR, the frontend detects import suggestions in compiler output and makes them clickable. On click, the suggestion is inserted at the top of the editor.

![playground1](https://user-images.githubusercontent.com/1740713/78450437-3f20d400-7687-11ea-8c2a-a67f2e5a0edf.png)
![playground2](https://user-images.githubusercontent.com/1740713/78450439-3fb96a80-7687-11ea-9ac3-8d27c24eec0b.png)

Inserting imports at the beginning is not ideal. Ideally, the new import should go at the end of the imports block, and the imports block should be separated from items with an empty line. Also it won't work if the compile error originates from a nested module. However, the frontend doesn't seem to have tools for more sophisticated behavior, and this implementation greatly simplifies preparing a working snippet the most common case.

Closes #404.