### PR TITLE
Add "Macro expand" tool to Playground

### DIFF
--- a/tests/spec/features/highlighting_error_output_spec.rb
+++ b/tests/spec/features/highlighting_error_output_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature "Highlighting the output", type: :feature, js: true do
 
   scenario "github see-issues are links" do
     within('.output-stderr') do
-      expect(page).to have_link('see issue #44580 <https://github.com/rust-lang/rust/issues/44580>', href: 'https://github.com/rust-lang/rust/issues/23416')
+      expect(page).to have_link('see issue #23416 <https://github.com/rust-lang/rust/issues/23416>', href: 'https://github.com/rust-lang/rust/issues/23416')
     end
   end
 

--- a/tests/spec/features/tools_spec.rb
+++ b/tests/spec/features/tools_spec.rb
@@ -44,7 +44,7 @@ RSpec.feature "Using third-party Rust tools", type: :feature, js: true do
     in_tools_menu { click_on("Miri") }
 
     within(".output-stderr") do
-      expect(page).to have_content %r{pointer must be in-bounds at offset 1, but is outside bounds of allocation \d+ which has size 0}
+      expect(page).to have_content %r{pointer must be in-bounds at offset 1, but is outside bounds of alloc\d+ which has size 0}
     end
   end
 

--- a/ui/frontend/Output.tsx
+++ b/ui/frontend/Output.tsx
@@ -45,7 +45,7 @@ interface PaneWithCodeProps extends SimplePaneProps {
 
 const Output: React.SFC = () => {
   const somethingToShow = useSelector(selectors.getSomethingToShow);
-  const { meta: { focus }, execute, format, clippy, miri, assembly, llvmIr, mir, wasm, gist } =
+  const { meta: { focus }, execute, format, clippy, miri, macroExpansion, assembly, llvmIr, mir, wasm, gist } =
     useSelector((state: State) => state.output);
 
   const dispatch = useDispatch();
@@ -54,6 +54,7 @@ const Output: React.SFC = () => {
   const focusFormat = useCallback(() => dispatch(actions.changeFocus(Focus.Format)), [dispatch]);
   const focusClippy = useCallback(() => dispatch(actions.changeFocus(Focus.Clippy)), [dispatch]);
   const focusMiri = useCallback(() => dispatch(actions.changeFocus(Focus.Miri)), [dispatch]);
+  const focusMacroExpansion = useCallback(() => dispatch(actions.changeFocus(Focus.MacroExpansion)), [dispatch]);
   const focusAssembly = useCallback(() => dispatch(actions.changeFocus(Focus.Asm)), [dispatch]);
   const focusLlvmIr = useCallback(() => dispatch(actions.changeFocus(Focus.LlvmIr)), [dispatch]);
   const focusMir = useCallback(() => dispatch(actions.changeFocus(Focus.Mir)), [dispatch]);
@@ -78,6 +79,7 @@ const Output: React.SFC = () => {
         {focus === Focus.Format && <SimplePane {...format} kind="format" />}
         {focus === Focus.Clippy && <SimplePane {...clippy} kind="clippy" />}
         {focus === Focus.Miri && <SimplePane {...miri} kind="miri" />}
+        {focus === Focus.MacroExpansion && <SimplePane {...macroExpansion} kind="macro-expansion" />}
         {focus === Focus.Asm && <PaneWithCode {...assembly} kind="asm" />}
         {focus === Focus.LlvmIr && <PaneWithCode {...llvmIr} kind="llvm-ir" />}
         {focus === Focus.Mir && <PaneWithCode {...mir} kind="mir" />}
@@ -106,6 +108,10 @@ const Output: React.SFC = () => {
           label="Miri"
           onClick={focusMiri}
           tabProps={miri} />
+        <Tab kind={Focus.MacroExpansion} focus={focus}
+          label="Macro expansion"
+          onClick={focusMacroExpansion}
+          tabProps={macroExpansion} />
         <Tab kind={Focus.Asm} focus={focus}
           label="ASM"
           onClick={focusAssembly}

--- a/ui/frontend/ToolsMenu.tsx
+++ b/ui/frontend/ToolsMenu.tsx
@@ -18,6 +18,8 @@ const ToolsMenu: React.SFC<ToolsMenuProps> = props => {
   const clippyVersion = useSelector(selectors.clippyVersionText);
   const miriVersionDetails = useSelector(selectors.miriVersionDetailsText);
   const miriVersion = useSelector(selectors.miriVersionText);
+  const nightlyVersion = useSelector(selectors.nightlyVersionText);
+  const nightlyVersionDetails = useSelector(selectors.nightlyVersionDetailsText);
 
   const dispatch = useDispatch();
   const clippy = useCallback(() => {
@@ -30,6 +32,10 @@ const ToolsMenu: React.SFC<ToolsMenuProps> = props => {
   }, [dispatch, props]);
   const format = useCallback(() => {
     dispatch(actions.performFormat());
+    props.close();
+  }, [dispatch, props]);
+  const expandMacros = useCallback(() => {
+    dispatch(actions.performMacroExpansion());
     props.close();
   }, [dispatch, props]);
 
@@ -55,6 +61,14 @@ const ToolsMenu: React.SFC<ToolsMenuProps> = props => {
           cases of undefined behavior (like out-of-bounds memory access).
         </div>
         <div className="tools-menu__aside">{miriVersion} ({miriVersionDetails})</div>
+      </ButtonMenuItem>
+      <ButtonMenuItem
+        name="Expand macros"
+        onClick={expandMacros}>
+        <div>
+          Expand macros in code using the nightly compiler.
+        </div>
+        <div className="tools-menu__aside">{nightlyVersion} ({nightlyVersionDetails})</div>
       </ButtonMenuItem>
     </MenuGroup>
   );

--- a/ui/frontend/reducers/output/index.ts
+++ b/ui/frontend/reducers/output/index.ts
@@ -9,6 +9,7 @@ import llvmIr from './llvmIr';
 import meta from './meta';
 import mir from './mir';
 import miri from './miri';
+import macroExpansion from './macroExpansion';
 import wasm from './wasm';
 
 const output = combineReducers({
@@ -16,6 +17,7 @@ const output = combineReducers({
   format,
   clippy,
   miri,
+  macroExpansion,
   assembly,
   llvmIr,
   mir,

--- a/ui/frontend/reducers/output/macroExpansion.ts
+++ b/ui/frontend/reducers/output/macroExpansion.ts
@@ -1,0 +1,31 @@
+import { Action, ActionType } from '../../actions';
+import { finish, start } from './sharedStateManagement';
+
+const DEFAULT: State = {
+  requestsInProgress: 0,
+  stdout: null,
+  stderr: null,
+  error: null,
+};
+
+interface State {
+  requestsInProgress: number;
+  stdout?: string;
+  stderr?: string;
+  error?: string;
+}
+
+export default function macroExpansion(state = DEFAULT, action: Action) {
+  switch (action.type) {
+    case ActionType.RequestMacroExpansion:
+      return start(DEFAULT, state);
+    case ActionType.MacroExpansionSucceeded: {
+      const { stdout = '', stderr = '' } = action;
+      return finish(state, { stdout, stderr });
+    }
+    case ActionType.MacroExpansionFailed:
+      return finish(state, { error: action.error });
+    default:
+      return state;
+  }
+}

--- a/ui/frontend/reducers/output/meta.ts
+++ b/ui/frontend/reducers/output/meta.ts
@@ -20,6 +20,9 @@ export default function meta(state = DEFAULT, action: Action) {
     case ActionType.RequestMiri:
       return { ...state, focus: Focus.Miri };
 
+    case ActionType.RequestMacroExpansion:
+      return { ...state, focus: Focus.MacroExpansion };
+
     case ActionType.CompileLlvmIrRequest:
       return { ...state, focus: Focus.LlvmIr };
 

--- a/ui/frontend/selectors/index.ts
+++ b/ui/frontend/selectors/index.ts
@@ -143,6 +143,7 @@ const getOutputs = (state: State) => [
   state.output.llvmIr,
   state.output.mir,
   state.output.miri,
+  state.output.macroExpansion,
   state.output.wasm,
 ];
 

--- a/ui/frontend/types.ts
+++ b/ui/frontend/types.ts
@@ -96,6 +96,7 @@ export enum Backtrace {
 export enum Focus {
   Clippy = 'clippy',
   Miri = 'miri',
+  MacroExpansion = 'macro-expansion',
   LlvmIr = 'llvm-ir',
   Mir = 'mir',
   Wasm = 'wasm',


### PR DESCRIPTION
This PR add new tool "Macro expand" to Playground  (#158). Under the hood it call `cargo run -- --Zunstable-options --pretty=expanded` with nightly compiler.


How it looks:
![image](https://user-images.githubusercontent.com/10746427/82097881-782f7800-970c-11ea-8f0e-527bba608648.png)