### PR TITLE
fix: fit the playground height to the parent view height

### DIFF
--- a/ui/frontend/index.scss
+++ b/ui/frontend/index.scss
@@ -78,7 +78,7 @@ body {
 
     &-split {
         display: flex;
-        height: 100vh;
+        height: 100%;
 
         &-automatic {
             @media screen and (max-width: 1600px) {


### PR DESCRIPTION
The playground height does not fit into its parent height, so the extra scrolling happens.
This PR changes playground height to 100% to match the parent view height.

Before:
![rust_playground_before](https://user-images.githubusercontent.com/774945/86526086-5069be80-beca-11ea-8494-f9f688606ff9.gif)

After:
![rust_playground_after](https://user-images.githubusercontent.com/774945/86526087-5364af00-beca-11ea-8830-a6c5a42486b4.gif)

