### PR TITLE
fix some a11y issues

### DIFF
--- a/ui/frontend/index.ejs
+++ b/ui/frontend/index.ejs
@@ -1,11 +1,14 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <meta name="description" content="A browser interface to the Rust compiler to experiment with the language" />
     <title><%= htmlWebpackPlugin.options.title %></title>
     <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,600,700%7CSource+Code+Pro:400,700&amp;subset=latin-ext" rel="stylesheet">
   </head>
-  <body>
-    <div id="playground"></div>
-  </body>
+  <main>
+    <body>
+      <div id="playground"></div>
+    </body>
+  </main>
 </html>


### PR DESCRIPTION
these accessibility issues were low-hanging fruit, so addressing in one commit:

- add a lang attribute to the html element
- add a meta description (also counts for the SEO lighthouse score)
- add a landmark (main) to the page