### PR TITLE
Format expanded Rust macros

### DIFF
--- a/ui/src/sandbox.rs
+++ b/ui/src/sandbox.rs
@@ -383,11 +383,9 @@ impl Sandbox {
         cmd.apply_edition(req);
 
         cmd.arg(&Channel::Nightly.container_name()).args(&[
-            "cargo",
-            "rustc",
-            "--",
-            "-Zunstable-options",
-            "--pretty=expanded",
+            "/bin/sh",
+            "-c",
+            "cargo rustc -- -Zunstable-options --pretty=expanded | rustfmt",
         ]);
 
         log::debug!("Macro expansion command is {:?}", cmd);


### PR DESCRIPTION
In the find of formatting Rust expanded code, is passing output of `cargo rustc` docker 
to another docker running `rustfmt` seems sensible.

In this PR, I try piping `cargo rustc | rustfmt` in the same docker. 
I don't know if the codebase will pass any others flags to `cargo rustc`.
If the code changed and did that, we may have shell injection vulnerable.

I am open to discuss about these problems.