### PR TITLE
Add a button in the toolbar to reset the editor

### DIFF
--- a/ui/frontend/AdvancedResetMenu.tsx
+++ b/ui/frontend/AdvancedResetMenu.tsx
@@ -1,0 +1,37 @@
+import React, { useCallback } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import ButtonMenuItem from './ButtonMenuItem';
+import MenuGroup from './MenuGroup';
+
+import * as selectors from './selectors';
+import * as actions from './actions';
+
+interface AdvancedResetMenuProps {
+  close: () => void;
+}
+
+const AdvancedResetMenu: React.SFC<AdvancedResetMenuProps> = props => {
+  const dispatch = useDispatch();
+  const resetToMinimal = useCallback(() => {
+    dispatch(actions.resetEditorToMinimal());
+    props.close();
+  }, [dispatch, props]);
+  const resetToHello = useCallback(() => {
+    dispatch(actions.resetEditorToHello());
+    props.close();
+  }, [dispatch, props]);
+
+  return (
+    <MenuGroup title="Reset Editor">
+      <ButtonMenuItem name="Reset to a minimal executable code" onClick={resetToMinimal}>
+        <div>Reset the editor content with just an empty main function.</div>
+      </ButtonMenuItem>
+      <ButtonMenuItem name='Reset to an "Hello World"' onClick={resetToHello}>
+        <div>Reset the editor content with an "Hello World" executable.</div>
+      </ButtonMenuItem>
+    </MenuGroup>
+  );
+};
+
+export default AdvancedResetMenu;

--- a/ui/frontend/Header.tsx
+++ b/ui/frontend/Header.tsx
@@ -11,6 +11,7 @@ import ModeMenu from './ModeMenu';
 import PopButton from './PopButton';
 import { SegmentedButton, SegmentedButtonSet, SegmentedLink } from './SegmentedButton';
 import ToolsMenu from './ToolsMenu';
+import AdvancedResetMenu from './AdvancedResetMenu';
 
 import * as actions from './actions';
 import * as selectors from './selectors';
@@ -28,6 +29,12 @@ const Header: React.SFC = () => (
         <ModeMenuButton />
         <ChannelMenuButton />
         <AdvancedOptionsMenuButton />
+      </SegmentedButtonSet>
+    </HeaderSet>
+    <HeaderSet id="reset">
+      <SegmentedButtonSet>
+        <ResetButton />
+        <AdvancedResetMenuButton />
       </SegmentedButtonSet>
     </HeaderSet>
     <HeaderSet id="share">
@@ -124,6 +131,28 @@ const AdvancedOptionsMenuButton: React.SFC = () => {
   Button.displayName = 'AdvancedOptionsMenuButton.Button';
 
   return <PopButton Button={Button} Menu={AdvancedOptionsMenu} />;
+}
+
+const ResetButton: React.SFC = () => {
+  const dispatch = useDispatch();
+  const resetAction = useCallback(() => dispatch(actions.resetEditorToEmpty()), [dispatch]);
+
+  return (
+    <SegmentedButton title="Reset the editor" onClick={resetAction}>
+      <HeaderButton>Reset</HeaderButton>
+    </SegmentedButton>
+  );
+};
+
+const AdvancedResetMenuButton: React.SFC = () => {
+  const Button = React.forwardRef<HTMLButtonElement, { toggle: () => void }>(({ toggle }, ref) => (
+    <SegmentedButton title="Reset the editor with some default content" ref={ref} onClick={toggle}>
+      <HeaderButton icon={<MoreOptionsIcon />} />
+    </SegmentedButton>
+  ));
+  Button.displayName = 'AdvancedResetMenuButton.Button';
+
+  return <PopButton Button={Button} Menu={AdvancedResetMenu} />;
 }
 
 const ShareButton: React.SFC = () => {

--- a/ui/frontend/actions.ts
+++ b/ui/frontend/actions.ts
@@ -118,6 +118,9 @@ export enum ActionType {
   RequestVersionsLoad = 'REQUEST_VERSIONS_LOAD',
   VersionsLoadSucceeded = 'VERSIONS_LOAD_SUCCEEDED',
   NotificationSeen = 'NOTIFICATION_SEEN',
+  ResetEditorToEmpty = 'RESET_EDITOR_TO_EMPTY',
+  ResetEditorToMinimal = 'RESET_EDITOR_TO_MINIMAL',
+  ResetEditorToHelloWorld = 'RESET_EDITOR_TO_HELLOWORLD',
 }
 
 const setPage = (page: Page) =>
@@ -419,6 +422,15 @@ export const performCompileToMir =
   performAndSwitchPrimaryAction(performCompileToMirOnly, PrimaryActionCore.Mir);
 export const performCompileToNightlyWasm =
   performAndSwitchPrimaryAction(performCompileToNightlyWasmOnly, PrimaryActionCore.Wasm);
+
+export const resetEditorToEmpty = () =>
+  createAction(ActionType.ResetEditorToEmpty);
+
+export const resetEditorToMinimal = () =>
+  createAction(ActionType.ResetEditorToMinimal);
+
+export const resetEditorToHello = () =>
+  createAction(ActionType.ResetEditorToHelloWorld);
 
 export const editCode = (code: string) =>
   createAction(ActionType.EditCode, { code });
@@ -822,4 +834,7 @@ export type Action =
   | ReturnType<typeof requestVersionsLoad>
   | ReturnType<typeof receiveVersionsLoadSuccess>
   | ReturnType<typeof notificationSeen>
+  | ReturnType<typeof resetEditorToEmpty>
+  | ReturnType<typeof resetEditorToMinimal>
+  | ReturnType<typeof resetEditorToHello>
   ;

--- a/ui/frontend/index.scss
+++ b/ui/frontend/index.scss
@@ -460,7 +460,7 @@ $header-transition: 0.2s ease-in-out;
       margin-right: 0;
     }
 
-    &--channel-mode {
+    &--reset {
       margin-right: auto;
     }
   }

--- a/ui/frontend/reducers/code.ts
+++ b/ui/frontend/reducers/code.ts
@@ -4,6 +4,9 @@ const DEFAULT: State = `fn main() {
     println!("Hello, world!");
 }`;
 
+const EMPTY_MAIN: State = `fn main() {
+}`;
+
 export type State = string;
 
 export default function code(state = DEFAULT, action: Action): State {
@@ -27,6 +30,15 @@ export default function code(state = DEFAULT, action: Action): State {
 
     case ActionType.FormatSucceeded:
       return action.code;
+
+    case ActionType.ResetEditorToEmpty:
+      return '';
+
+    case ActionType.ResetEditorToMinimal:
+      return EMPTY_MAIN;
+
+    case ActionType.ResetEditorToHelloWorld:
+      return DEFAULT;
 
     default:
       return state;


### PR DESCRIPTION
Fixes the issue #323 .

It add a button to reset the content of the editor. The session storage is also updated.

![image](https://user-images.githubusercontent.com/9797898/91850218-73f87d80-ec5d-11ea-8bdf-32e08f1b1dc0.png)
