### PR TITLE
explicitly use 'cargo miri run'

### DIFF
--- a/compiler/miri/cargo-miri-playground
+++ b/compiler/miri/cargo-miri-playground
@@ -3,4 +3,4 @@
 set -eu
 
 export MIRI_SYSROOT=~/.cache/miri/HOST
-exec cargo miri
+exec cargo miri run


### PR DESCRIPTION
The old `cargo miri` does not work any more, the subcommand must be given explicitly.

(The only reason Miri works on the the playground website right now is that it is using an outdated Miri.)