### PR TITLE
Stop the MIR source regex from being greedy

### DIFF
--- a/ui/frontend/highlighting.ts
+++ b/ui/frontend/highlighting.ts
@@ -51,7 +51,7 @@ export function configureRustErrors({
   };
 
   Prism.languages.rust_mir = {
-    'mir-source': /src\/.*.rs:\d+:\d+: \d+:\d+/,
+    'mir-source': /src\/[A-Za-z0-9_.\-]+\.rs:\d+:\d+: \d+:\d+/,
   }
 
   Prism.hooks.add('wrap', env => {


### PR DESCRIPTION
Otherwise it would highlight too much of the line if there were multiple MIR
sources. For example with [this playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=30970d3e39b0bfcba0120b04385da47e), it would highlight the line like this:

> let mut _0: \[closure@[src/main.rs:6:5: 6:23 y:i32\]; // return place in scope 0 at src/main.rs:5:19: 5:38]()
