### PR TITLE
Disable page navigation on swipe

### DIFF
--- a/ui/frontend/index.scss
+++ b/ui/frontend/index.scss
@@ -9,6 +9,11 @@ $border: 1px solid $border-color;
 
 $primary-font: 'Open Sans', sans-serif;
 
+// Disable page navigation on swipe
+html, body {
+    overscroll-behavior-x: none;
+}
+
 // Modify normalized styles
 button,
 input,


### PR DESCRIPTION
I'm on MacOS, and swiping with two fingers left or right goes to the previous/next page. This interferes with horizontal scrolling in the editor.

I am not a CSS expert, but this works for me on MacOS.