### PR TITLE
Remove "Open an issue" link

### DIFF
--- a/tests/spec/features/sharing_with_others_spec.rb
+++ b/tests/spec/features/sharing_with_others_spec.rb
@@ -22,7 +22,6 @@ RSpec.feature "Sharing the code with others", type: :feature, js: true do
     perma_link = find_link("Permalink to the playground")[:href]
     direct_link = find_link("Direct link to the gist")[:href]
     urlo_link = find_link("Open a new thread in the Rust user forum")[:href]
-    issue_link = find_link("Open an issue on the Rust GitHub repository")[:href]
 
     # Navigate away so we can tell that we go back to the same page
     visit 'about:blank'
@@ -41,10 +40,6 @@ RSpec.feature "Sharing the code with others", type: :feature, js: true do
     # Need to be logged in to URLO for this link to work
     expect(urlo_link).to match(%r{https://users.rust-lang.org/new-topic})
     expect(urlo_link).to match(%{automated%20test})
-
-    # Need to be logged in to GitHub for this link to work
-    expect(issue_link).to match(%r{https://github.com/rust-lang/rust/issues/new})
-    expect(issue_link).to match(%{automated%20test})
   end
 
   def editor

--- a/ui/frontend/Output/Gist.tsx
+++ b/ui/frontend/Output/Gist.tsx
@@ -55,7 +55,6 @@ class Copied extends React.PureComponent<CopiedProps, CopiedState> {
 const Links: React.SFC = () => {
   const codeUrl = useSelector(selectors.codeUrlSelector);
   const gistUrl = useSelector((state: State) => state.output.gist.url);
-  const issueUrl = useSelector(selectors.issueUrlSelector);
   const permalink = useSelector(selectors.permalinkSelector);
   const urloUrl = useSelector(selectors.urloUrlSelector);
 
@@ -65,7 +64,6 @@ const Links: React.SFC = () => {
       <Copied href={gistUrl}>Direct link to the gist</Copied>
       <Copied href={codeUrl}>Embedded code in link</Copied>
       <NewWindow href={urloUrl}>Open a new thread in the Rust user forum</NewWindow>
-      <NewWindow href={issueUrl}> Open an issue on the Rust GitHub repository</NewWindow>
     </Fragment>
   );
 };

--- a/ui/frontend/selectors/index.ts
+++ b/ui/frontend/selectors/index.ts
@@ -237,15 +237,6 @@ export const urloUrlSelector = createSelector(
   },
 );
 
-export const issueUrlSelector = createSelector(
-  snippetSelector,
-  snippet => {
-    const newIssueUrl = url.parse('https://github.com/rust-lang/rust/issues/new', true);
-    newIssueUrl.query = { body: snippet };
-    return url.format(newIssueUrl);
-  },
-);
-
 export const codeUrlSelector = createSelector(
   baseUrlSelector, urlQuerySelector, gistSelector,
   (baseUrl, query, gist) => {


### PR DESCRIPTION
Fixes https://github.com/integer32llc/rust-playground/issues/671

Didn't test this locally because the frontend doesn't build on my machine