### PR TITLE
Detect `unsafe fn main() { ... }`

### DIFF
--- a/ui/frontend/selectors/index.spec.ts
+++ b/ui/frontend/selectors/index.spec.ts
@@ -37,6 +37,14 @@ describe('checking for a main function', () => {
     expect(hasMainFunctionSelector(buildState('pub const fn main()'))).toBe(true);
   });
 
+  test('an unsafe main counts', () => {
+    expect(hasMainFunctionSelector(buildState('unsafe fn main()'))).toBe(true);
+  });
+
+  test('a public unsafe main counts', () => {
+    expect(hasMainFunctionSelector(buildState('pub unsafe fn main()'))).toBe(true);
+  });
+  
   test('a public const async main counts', () => {
     expect(hasMainFunctionSelector(buildState('pub const async fn main()'))).toBe(true);
   });

--- a/ui/frontend/selectors/index.ts
+++ b/ui/frontend/selectors/index.ts
@@ -10,7 +10,7 @@ const codeSelector = (state: State) => state.code;
 const HAS_TESTS_RE = /^\s*#\s*\[\s*test\s*([^"]*)]/m;
 export const hasTestsSelector = createSelector(codeSelector, code => !!code.match(HAS_TESTS_RE));
 
-const HAS_MAIN_FUNCTION_RE = /^\s*(pub\s+)?\s*(const\s+)?\s*(async\s+)?\s*fn\s+main\s*\(\s*\)/m;
+const HAS_MAIN_FUNCTION_RE = /^\s*(pub\s+)?\s*(const\s+)?\s*(async\s+)?\s*(unsafe\s+)?\s*fn\s+main\s*\(\s*\)/m;
 export const hasMainFunctionSelector = createSelector(codeSelector, code => !!code.match(HAS_MAIN_FUNCTION_RE));
 
 const CRATE_TYPE_RE = /^\s*#!\s*\[\s*crate_type\s*=\s*"([^"]*)"\s*]/m;


### PR DESCRIPTION
Currently the playground doesn't detect this `main` function:
```rust
unsafe fn main() {}
```