### PR TITLE
Prevent expanding the window size when adjusting the split

### DIFF
--- a/ui/frontend/Playground.module.css
+++ b/ui/frontend/Playground.module.css
@@ -40,6 +40,10 @@ $splitSecondaryDimension: 1fr;
 .splitRowsGutter {
   composes: -gutter;
   cursor: row-resize;
+}
+
+.splitRowsGutterHandle {
+  pointer-events: none;
   transform: rotate(90deg);
 }
 

--- a/ui/frontend/Playground.tsx
+++ b/ui/frontend/Playground.tsx
@@ -44,7 +44,9 @@ const SplitRows: React.SFC<SplitProps> = ({ resizeComplete }) => (
     }) => (
       <div className={styles.splitRows} {...getGridProps()}>
         <div className={styles.editor}><Editor /></div>
-        <div className={styles.splitRowsGutter} {...getGutterProps('row', 1)}>⣿</div>
+        <div className={styles.splitRowsGutter} {...getGutterProps('row', 1)}>
+          <span className={styles.splitRowsGutterHandle}>⣿</span>
+        </div>
         <div className={styles.output}><Output /></div>
       </div>
     )} />


### PR DESCRIPTION
Since we were rotating the *entire* gutter, it would easily extend
beyond the window boundaries, adding a scrollbar to the entire
playground. Instead, rotate only the handle icon itself. Due to [a
limitation with split.js][limitation], we have to also ignore pointer
events on the handle since it's now a child of the gutter.

[limitation]: https://github.com/nathancahill/split/issues/354