### PR TITLE
Use `--unpretty=expanded` instead of `--pretty`

### DIFF
--- a/ui/src/sandbox.rs
+++ b/ui/src/sandbox.rs
@@ -398,8 +398,7 @@ impl Sandbox {
             "cargo",
             "rustc",
             "--",
-            "-Zunstable-options",
-            "--pretty=expanded",
+            "-Zunpretty=expanded",
         ]);
 
         log::debug!("Macro expansion command is {:?}", cmd);


### PR DESCRIPTION
I'm considering removing `--pretty` in https://github.com/rust-lang/rust/pull/83491, which would break playground. If we decide #83491 should go forward, this unblocks it.