### PR TITLE
Add support for `-Zunpretty=ast-tree`

### DIFF
--- a/tests/spec/features/compilation_targets_spec.rb
+++ b/tests/spec/features/compilation_targets_spec.rb
@@ -106,6 +106,18 @@ RSpec.feature "Compiling to different formats", type: :feature, js: true do
     end
   end
 
+  scenario "compiling to AST" do
+    editor.set <<~EOF
+      fn demo() -> impl std::fmt::Display { 42 }
+    EOF
+
+    in_build_menu { click_on("AST") }
+
+    within(:output, :result) do
+      expect(page).to have_content 'ident: demo#0,'
+    end
+  end
+
   scenario "compiling to WebAssembly" do
     in_build_menu { click_on("WASM") }
 

--- a/ui/frontend/BuildMenu.tsx
+++ b/ui/frontend/BuildMenu.tsx
@@ -28,6 +28,7 @@ const useDispatchAndClose = (action: () => void, close: () => void) => {
 
 const BuildMenu: React.SFC<BuildMenuProps> = props => {
   const isHirAvailable = useSelector(selectors.isHirAvailable);
+  const isAstAvailable = useSelector(selectors.isAstAvailable);
   const isWasmAvailable = useSelector(selectors.isWasmAvailable);
 
   const compile = useDispatchAndClose(actions.performCompile, props.close);
@@ -35,6 +36,7 @@ const BuildMenu: React.SFC<BuildMenuProps> = props => {
   const compileToLLVM = useDispatchAndClose(actions.performCompileToLLVM, props.close);
   const compileToMir = useDispatchAndClose(actions.performCompileToMir, props.close);
   const compileToHir = useDispatchAndClose(actions.performCompileToNightlyHir, props.close);
+  const compileToAst = useDispatchAndClose(actions.performCompileToNightlyAst, props.close);
   const compileToWasm = useDispatchAndClose(actions.performCompileToNightlyWasm, props.close);
   const execute = useDispatchAndClose(actions.performExecute, props.close);
   const test = useDispatchAndClose(actions.performTest, props.close);
@@ -66,6 +68,10 @@ const BuildMenu: React.SFC<BuildMenuProps> = props => {
         Build and show the resulting HIR, Rust’s syntax-based intermediate representation.
         {!isHirAvailable && <HirAside />}
       </ButtonMenuItem>
+      <ButtonMenuItem name="AST" onClick={compileToAst}>
+        Build and show the resulting AST.
+        {!isAstAvailable && <HirAside />}
+      </ButtonMenuItem>
       <ButtonMenuItem name="WASM" onClick={compileToWasm}>
         Build a WebAssembly module for web browsers, in the .WAT textual representation.
         {!isWasmAvailable && <WasmAside />}
@@ -77,6 +83,13 @@ const BuildMenu: React.SFC<BuildMenuProps> = props => {
 const HirAside: React.SFC = () => (
   <MenuAside>
     Note: HIR currently requires using the Nightly channel, selecting this
+    option will switch to Nightly.
+  </MenuAside>
+);
+
+const AstAside: React.SFC = () => (
+  <MenuAside>
+    Note: AST currently requires using the Nightly channel, selecting this
     option will switch to Nightly.
   </MenuAside>
 );

--- a/ui/frontend/Output.tsx
+++ b/ui/frontend/Output.tsx
@@ -47,7 +47,7 @@ interface PaneWithCodeProps extends SimplePaneProps {
 
 const Output: React.SFC = () => {
   const somethingToShow = useSelector(selectors.getSomethingToShow);
-  const { meta: { focus }, execute, format, clippy, miri, macroExpansion, assembly, llvmIr, mir, hir, wasm, gist } =
+  const { meta: { focus }, execute, format, clippy, miri, macroExpansion, assembly, llvmIr, mir, hir, ast, wasm, gist } =
     useSelector((state: State) => state.output);
 
   const dispatch = useDispatch();
@@ -61,6 +61,7 @@ const Output: React.SFC = () => {
   const focusLlvmIr = useCallback(() => dispatch(actions.changeFocus(Focus.LlvmIr)), [dispatch]);
   const focusMir = useCallback(() => dispatch(actions.changeFocus(Focus.Mir)), [dispatch]);
   const focusHir = useCallback(() => dispatch(actions.changeFocus(Focus.Hir)), [dispatch]);
+  const focusAst = useCallback(() => dispatch(actions.changeFocus(Focus.Ast)), [dispatch]);
   const focusWasm = useCallback(() => dispatch(actions.changeFocus(Focus.Wasm)), [dispatch]);
   const focusGist = useCallback(() => dispatch(actions.changeFocus(Focus.Gist)), [dispatch]);
 
@@ -84,6 +85,7 @@ const Output: React.SFC = () => {
         {focus === Focus.LlvmIr && <PaneWithCode {...llvmIr} kind="llvm-ir" />}
         {focus === Focus.Mir && <PaneWithMir {...mir} kind="mir" />}
         {focus === Focus.Hir && <PaneWithMir {...hir} kind="hir" />}
+        {focus === Focus.Ast && <PaneWithMir {...ast} kind="ast" />}
         {focus === Focus.Wasm && <PaneWithCode {...wasm} kind="wasm" />}
         {focus === Focus.Gist && <Gist />}
       </div>
@@ -129,6 +131,10 @@ const Output: React.SFC = () => {
           label="HIR"
           onClick={focusHir}
           tabProps={hir} />
+        <Tab kind={Focus.Ast} focus={focus}
+          label="AST"
+          onClick={focusAst}
+          tabProps={ast} />
         <Tab kind={Focus.Wasm} focus={focus}
           label="WASM"
           onClick={focusWasm}

--- a/ui/frontend/actions.ts
+++ b/ui/frontend/actions.ts
@@ -84,6 +84,9 @@ export enum ActionType {
   CompileLlvmIrRequest = 'COMPILE_LLVM_IR_REQUEST',
   CompileLlvmIrSucceeded = 'COMPILE_LLVM_IR_SUCCEEDED',
   CompileLlvmIrFailed = 'COMPILE_LLVM_IR_FAILED',
+  CompileAstRequest = 'COMPILE_AST_REQUEST',
+  CompileAstSucceeded = 'COMPILE_AST_SUCCEEDED',
+  CompileAstFailed = 'COMPILE_AST_FAILED',
   CompileHirRequest = 'COMPILE_HIR_REQUEST',
   CompileHirSucceeded = 'COMPILE_HIR_SUCCEEDED',
   CompileHirFailed = 'COMPILE_HIR_FAILED',
@@ -359,6 +362,27 @@ const performCompileToLLVMOnly = () =>
     failure: receiveCompileLlvmIrFailure,
   });
 
+const requestCompileAst = () =>
+  createAction(ActionType.CompileAstRequest);
+
+const receiveCompileAstSuccess = ({ code, stdout, stderr }) =>
+  createAction(ActionType.CompileAstSucceeded, { code, stdout, stderr });
+
+const receiveCompileAstFailure = ({ error }) =>
+  createAction(ActionType.CompileAstFailed, { error });
+
+const performCompileToAstOnly = () =>
+  performCompileShow('ast', {
+    request: requestCompileAst,
+    success: receiveCompileAstSuccess,
+    failure: receiveCompileAstFailure,
+  });
+
+const performCompileToNightlyAstOnly = (): ThunkAction => dispatch => {
+  dispatch(changeChannel(Channel.Nightly));
+  dispatch(performCompileToAstOnly());
+};
+
 const requestCompileHir = () =>
   createAction(ActionType.CompileHirRequest);
 
@@ -424,6 +448,7 @@ const PRIMARY_ACTIONS: { [index in PrimaryAction]: () => ThunkAction } = {
   [PrimaryActionCore.Test]: performTestOnly,
   [PrimaryActionAuto.Auto]: performAutoOnly,
   [PrimaryActionCore.LlvmIr]: performCompileToLLVMOnly,
+  [PrimaryActionCore.Ast]: performCompileToAstOnly,
   [PrimaryActionCore.Hir]: performCompileToHirOnly,
   [PrimaryActionCore.Mir]: performCompileToMirOnly,
   [PrimaryActionCore.Wasm]: performCompileToNightlyWasmOnly,
@@ -454,6 +479,8 @@ export const performCompileToMir =
   performAndSwitchPrimaryAction(performCompileToMirOnly, PrimaryActionCore.Mir);
 export const performCompileToNightlyHir =
   performAndSwitchPrimaryAction(performCompileToNightlyHirOnly, PrimaryActionCore.Hir);
+  export const performCompileToNightlyAst =
+  performAndSwitchPrimaryAction(performCompileToNightlyAstOnly, PrimaryActionCore.Ast);
 export const performCompileToNightlyWasm =
   performAndSwitchPrimaryAction(performCompileToNightlyWasmOnly, PrimaryActionCore.Wasm);
 
@@ -838,6 +865,9 @@ export type Action =
   | ReturnType<typeof requestCompileHir>
   | ReturnType<typeof receiveCompileHirSuccess>
   | ReturnType<typeof receiveCompileHirFailure>
+  | ReturnType<typeof requestCompileAst>
+  | ReturnType<typeof receiveCompileAstSuccess>
+  | ReturnType<typeof receiveCompileAstFailure>
   | ReturnType<typeof requestCompileWasm>
   | ReturnType<typeof receiveCompileWasmSuccess>
   | ReturnType<typeof receiveCompileWasmFailure>

--- a/ui/frontend/reducers/output/ast.ts
+++ b/ui/frontend/reducers/output/ast.ts
@@ -1,0 +1,33 @@
+import { Action, ActionType } from '../../actions';
+import { finish, start } from './sharedStateManagement';
+
+const DEFAULT: State = {
+  requestsInProgress: 0,
+  code: null,
+  stdout: null,
+  stderr: null,
+  error: null,
+};
+
+interface State {
+  requestsInProgress: number;
+  code?: string;
+  stdout?: string;
+  stderr?: string;
+  error?: string;
+}
+
+export default function ast(state = DEFAULT, action: Action) {
+  switch (action.type) {
+    case ActionType.CompileAstRequest:
+      return start(DEFAULT, state);
+    case ActionType.CompileAstSucceeded: {
+      const { code = '', stdout = '', stderr = '' } = action;
+      return finish(state, { code, stdout, stderr });
+    }
+    case ActionType.CompileAstFailed:
+      return finish(state, { error: action.error });
+    default:
+      return state;
+  }
+}

--- a/ui/frontend/reducers/output/index.ts
+++ b/ui/frontend/reducers/output/index.ts
@@ -1,6 +1,7 @@
 import { combineReducers } from 'redux';
 
 import assembly from './assembly';
+import ast from './ast';
 import clippy from './clippy';
 import execute from './execute';
 import format from './format';
@@ -23,6 +24,7 @@ const output = combineReducers({
   llvmIr,
   mir,
   hir,
+  ast,
   wasm,
   execute,
   gist,

--- a/ui/frontend/reducers/output/meta.ts
+++ b/ui/frontend/reducers/output/meta.ts
@@ -31,6 +31,9 @@ export default function meta(state = DEFAULT, action: Action) {
 
     case ActionType.CompileHirRequest:
       return { ...state, focus: Focus.Hir };
+    
+    case ActionType.CompileAstRequest:
+      return { ...state, focus: Focus.Ast };
 
     case ActionType.CompileWasmRequest:
       return { ...state, focus: Focus.Wasm };

--- a/ui/frontend/selectors/index.ts
+++ b/ui/frontend/selectors/index.ts
@@ -71,6 +71,7 @@ const LABELS: { [index in PrimaryActionCore]: string } = {
   [PrimaryActionCore.Compile]: 'Build',
   [PrimaryActionCore.Execute]: 'Run',
   [PrimaryActionCore.LlvmIr]: 'Show LLVM IR',
+  [PrimaryActionCore.Ast]: 'Show AST',
   [PrimaryActionCore.Hir]: 'Show HIR',
   [PrimaryActionCore.Mir]: 'Show MIR',
   [PrimaryActionCore.Test]: 'Test',
@@ -108,6 +109,7 @@ export const isNightlyChannel = (state: State) => (
 );
 export const isWasmAvailable = isNightlyChannel;
 export const isHirAvailable = isNightlyChannel;
+export const isAstAvailable = isNightlyChannel;
 export const isRust2021Available = isNightlyChannel;
 
 export const getModeLabel = (state: State) => {
@@ -147,6 +149,7 @@ const getOutputs = (state: State) => [
   state.output.llvmIr,
   state.output.mir,
   state.output.hir,
+  state.output.ast,
   state.output.miri,
   state.output.macroExpansion,
   state.output.wasm,

--- a/ui/frontend/types.ts
+++ b/ui/frontend/types.ts
@@ -70,6 +70,7 @@ export enum PrimaryActionAuto {
 }
 
 export enum PrimaryActionCore {
+  Ast = 'ast',
   Asm = 'asm',
   Compile = 'compile',
   Execute = 'execute',
@@ -111,6 +112,7 @@ export enum Focus {
   LlvmIr = 'llvm-ir',
   Mir = 'mir',
   Hir = 'hir',
+  Ast = 'ast',
   Wasm = 'wasm',
   Asm = 'asm',
   Execute = 'execute',

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -1429,6 +1429,7 @@ fn parse_target(s: &str) -> Result<sandbox::CompileTarget> {
         "llvm-ir" => sandbox::CompileTarget::LlvmIr,
         "mir" => sandbox::CompileTarget::Mir,
         "hir" => sandbox::CompileTarget::Hir,
+        "ast" => sandbox::CompileTarget::Ast,
         "wasm" => sandbox::CompileTarget::Wasm,
         value => InvalidTarget { value }.fail()?,
     })

--- a/ui/src/sandbox.rs
+++ b/ui/src/sandbox.rs
@@ -484,6 +484,9 @@ fn build_execution_command(target: Option<CompileTarget>, channel: Channel, mode
         if target == Hir {
             // -Zunpretty=hir only emits the HIR, not the binary itself
             cmd.push("/playground-result/compilation.hir");
+        } else if target == Ast {
+            // -Zunpretty=ast-tree only emits the AST, not the binary itself
+            cmd.push("/playground-result/compilation.ast");
         } else {
             cmd.push("/playground-result/compilation");
         }
@@ -509,6 +512,7 @@ fn build_execution_command(target: Option<CompileTarget>, channel: Channel, mode
             LlvmIr => cmd.push("--emit=llvm-ir"),
             Mir => cmd.push("--emit=mir"),
             Hir => cmd.push("-Zunpretty=hir"),
+            Ast => cmd.push("-Zunpretty=ast-tree"),
             Wasm => { /* handled by cargo-wasm wrapper */ },
          }
     }
@@ -622,6 +626,7 @@ pub enum CompileTarget {
     LlvmIr,
     Mir,
     Hir,
+    Ast,
     Wasm,
 }
 
@@ -632,6 +637,7 @@ impl CompileTarget {
             CompileTarget::LlvmIr            => "ll",
             CompileTarget::Mir               => "mir",
             CompileTarget::Hir               => "hir",
+            CompileTarget::Ast               => "ast",
             CompileTarget::Wasm              => "wat",
         };
         OsStr::new(ext)
@@ -647,6 +653,7 @@ impl fmt::Display for CompileTarget {
             LlvmIr            => "LLVM IR".fmt(f),
             Mir               => "Rust MIR".fmt(f),
             Hir               => "Rust HIR".fmt(f),
+            Ast               => "Rust AST".fmt(f),
             Wasm              => "WebAssembly".fmt(f),
         }
     }


### PR DESCRIPTION
This is greatly based on #683 but for AST. Fixes #502 finally.