### PR TITLE
Remove special case for cargo "edition2021" feature

### DIFF
--- a/compiler/base/modify-cargo-toml/src/main.rs
+++ b/compiler/base/modify-cargo-toml/src/main.rs
@@ -20,10 +20,6 @@ fn main() {
     let mut cargo_toml: Value = toml::from_str(&input)
         .unwrap_or_else(|e| panic!("Cannot parse {} as TOML: {}", input_filename.display(), e));
 
-    if env::var_os("PLAYGROUND_FEATURE_EDITION2021").is_some() {
-        cargo_toml = set_feature_edition2021(cargo_toml);
-    }
-
     if let Ok(edition) = env::var("PLAYGROUND_EDITION") {
         cargo_toml = set_edition(cargo_toml, &edition);
     }
@@ -64,22 +60,6 @@ fn ensure_string_in_vec(values: &mut Vec<String>, val: &str) {
     if !values.iter().any(|f| f == val) {
         values.push(val.into());
     }
-}
-
-fn set_feature_edition2021(cargo_toml: Value) -> Value {
-    #[derive(Debug, Serialize, Deserialize)]
-    #[serde(rename_all = "kebab-case")]
-    struct CargoToml {
-        #[serde(default)]
-        cargo_features: Vec<String>,
-        #[serde(flatten)]
-        other: Other,
-    }
-
-    modify(cargo_toml, |mut cargo_toml: CargoToml| {
-        ensure_string_in_vec(&mut cargo_toml.cargo_features, "edition2021");
-        cargo_toml
-    })
 }
 
 fn set_edition(cargo_toml: Value, edition: &str) -> Value {

--- a/ui/src/sandbox.rs
+++ b/ui/src/sandbox.rs
@@ -753,10 +753,6 @@ impl DockerCommandExt for Command {
 
     fn apply_edition(&mut self, req: impl EditionRequest) {
         if let Some(edition) = req.edition() {
-            if edition == Edition::Rust2021 {
-                self.args(&["--env", &format!("PLAYGROUND_FEATURE_EDITION2021=true")]);
-            }
-
             self.args(&["--env", &format!("PLAYGROUND_EDITION={}", edition.cargo_ident())]);
         }
     }


### PR DESCRIPTION
It was only needed until the 2021 edition was stabilized in cargo, and this has been done on nighty and beta. 

We can see a warning cargo currently emits when using the edition 2021 on the playground, and this PR should fix that.