### PR TITLE
Add a magic comment syntax to set MIRIFLAGS

### DIFF
--- a/compiler/miri/cargo-miri-playground
+++ b/compiler/miri/cargo-miri-playground
@@ -3,5 +3,4 @@
 set -eu
 
 export MIRI_SYSROOT=~/.cache/miri/HOST
-export MIRIFLAGS="-Zmiri-disable-isolation"
 exec cargo miri run


### PR DESCRIPTION
Based on https://github.com/integer32llc/rust-playground/issues/446#issuecomment-670917927

I really want to be able to set `MIRIFLAGS` when running code in the playground. The community Discord uses a bot that accesses the playground and we use it for demos. It's a real bummer that any time `-Zmiri-tag-raw-pointers` is required to demonstrate something, we can't use the bot. I don't think changing the defaults is a particularly good option either, because we may want to make a point about the impact of `-Zmiri-tag-raw-pointers`. And I recently added `-Zmiri-backtrace` which should be left as its default, but in a pinch can remove backtraces entirely to make the output fit in Discord message length limit.