### PR TITLE
Make PLAYGROUND_GITHUB_TOKEN optional

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -6,15 +6,15 @@ disk in this directory.
 In production, these should be set according to your deployment method
 of choice.
 
-| Key                        | Required   | Default Value     | Description                                                               |
-| -------------------------- | ---------- | ----------------- | ------------------------------------------------------------------------- |
-| `PLAYGROUND_UI_ROOT`       | **Yes**    |                   | The path to the HTML, CSS, and Javascript files                           |
-| `PLAYGROUND_GITHUB_TOKEN`  | **Yes**    |                   | The [GitHub API token][gist] to read and write Gists                      |
-| `PLAYGROUND_UI_ADDRESS`    | No         | 127.0.0.1         | The address to listen on                                                  |
-| `PLAYGROUND_UI_PORT`       | No         | 5000              | The port to listen on                                                     |
-| `PLAYGROUND_METRICS_TOKEN` | No         |                   | If set, will require authentication for the metrics endpoint              |
-| `PLAYGROUND_CORS_ENABLED`  | No         |                   | If set, will enable CORS support                                          |
-| `TMPDIR`                   | No         | system-provided   | Where compilation artifacts will be saved. Must be accessible to Docker   |
+| Key                        | Required   | Default Value     | Description                                                                                                                 |
+| -------------------------- | ---------- | ----------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `PLAYGROUND_UI_ROOT`       | **Yes**    |                   | The path to the HTML, CSS, and Javascript files; for local testing probably you'll use: `PLAYGROUND_UI_ROOT=frontend/build` |
+| `PLAYGROUND_GITHUB_TOKEN`  | No         |                   | The [GitHub API token][gist] to read and write Gists                                                                        |
+| `PLAYGROUND_UI_ADDRESS`    | No         | 127.0.0.1         | The address to listen on                                                                                                    |
+| `PLAYGROUND_UI_PORT`       | No         | 5000              | The port to listen on                                                                                                       |
+| `PLAYGROUND_METRICS_TOKEN` | No         |                   | If set, will require authentication for the metrics endpoint                                                                |
+| `PLAYGROUND_CORS_ENABLED`  | No         |                   | If set, will enable CORS support                                                                                            |
+| `TMPDIR`                   | No         | system-provided   | Where compilation artifacts will be saved. Must be accessible to Docker                                                     |
 
 [dotenv]: https://crates.io/crates/dotenv
 [gist]: https://developer.github.com/v3/gists/#authentication

--- a/ui/src/env.rs
+++ b/ui/src/env.rs
@@ -1,0 +1,3 @@
+pub use std::env::*;
+
+pub const PLAYGROUND_GITHUB_TOKEN: &str = "PLAYGROUND_GITHUB_TOKEN";

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -1,10 +1,10 @@
 #![deny(rust_2018_idioms)]
 
+use crate::env::PLAYGROUND_GITHUB_TOKEN;
 use serde::{Deserialize, Serialize};
 use snafu::prelude::*;
 use std::{
     convert::TryFrom,
-    env,
     net::SocketAddr,
     path::{Path, PathBuf},
     sync::Arc,
@@ -14,6 +14,7 @@ const DEFAULT_ADDRESS: &str = "127.0.0.1";
 const DEFAULT_PORT: u16 = 5000;
 
 mod asm_cleanup;
+mod env;
 mod gist;
 mod metrics;
 mod sandbox;
@@ -54,7 +55,6 @@ impl Config {
             .and_then(|p| p.parse().ok())
             .unwrap_or(DEFAULT_PORT);
 
-        const PLAYGROUND_GITHUB_TOKEN: &str = "PLAYGROUND_GITHUB_TOKEN";
         let gh_token = env::var(PLAYGROUND_GITHUB_TOKEN).ok();
         if gh_token.is_none() {
             log::warn!("Environment variable {} is not set, so reading and writing GitHub gists will not work", PLAYGROUND_GITHUB_TOKEN);
@@ -149,7 +149,7 @@ pub enum Error {
     GistCreation { source: octocrab::Error },
     #[snafu(display("Gist loading failed: {}", source))]
     GistLoading { source: octocrab::Error },
-    #[snafu(display("PLAYGROUND_GITHUB_TOKEN not set up for reading/writing gists"))]
+    #[snafu(display("{PLAYGROUND_GITHUB_TOKEN} not set up for reading/writing gists"))]
     NoGithubToken,
     #[snafu(display("Unable to serialize response: {}", source))]
     Serialization { source: serde_json::Error },

--- a/ui/src/server_axum.rs
+++ b/ui/src/server_axum.rs
@@ -353,7 +353,7 @@ async fn meta_gist_create(
     Extension(token): Extension<GhToken>,
     Json(req): Json<MetaGistCreateRequest>,
 ) -> Result<Json<MetaGistResponse>> {
-    let token = String::clone(&token.0);
+    let token = token.must_get()?;
     gist::create_future(token, req.code)
         .await
         .map(Into::into)
@@ -365,7 +365,7 @@ async fn meta_gist_get(
     Extension(token): Extension<GhToken>,
     Path(id): Path<String>,
 ) -> Result<Json<MetaGistResponse>> {
-    let token = String::clone(&token.0);
+    let token = token.must_get()?;
     gist::load_future(token, &id)
         .await
         .map(Into::into)


### PR DESCRIPTION
I am working on a PR for something totally unrelated to gists, and didn't want to bother setting up a GitHub token just so that the server wouldn't crash on startup.