### PR TITLE
Format top-crates crate with rustfmt and check in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,11 +182,16 @@ jobs:
           ~/.cargo/git
           ui/target
         key: "${{ runner.os }}-cargo-${{ hashFiles('ui/**/Cargo.lock') }}-2"
-    - name: Format
+    - name: Format server
       uses: actions-rs/cargo@v1
       with:
         command: fmt
-        args: "--manifest-path ui/Cargo.toml --all -- --check"
+        args: "--manifest-path ui/Cargo.toml --all --check"
+    - name: Format top-crates
+      uses: actions-rs/cargo@v1
+      with:
+        command: fmt
+        args: "--manifest-path top-crates/Cargo.toml --check"
     - name: Build backend
       run: |-
         mkdir -p ui/target; docker run --rm -v $PWD/ui:/ui -v ~/.cargo/git:/home/rust/.cargo/git -v ~/.cargo/registry:/home/rust/.cargo/registry --workdir /ui ekidd/rust-musl-builder:stable bash -c $'

--- a/ci/workflows.yml
+++ b/ci/workflows.yml
@@ -279,11 +279,17 @@ workflows:
                 ui/target
               key: ${{ runner.os }}-cargo-${{ hashFiles('ui/**/Cargo.lock') }}-2
 
-          - name: "Format"
+          - name: "Format server"
             uses: actions-rs/cargo@v1
             with:
               command: fmt
-              args: --manifest-path ui/Cargo.toml --all -- --check
+              args: --manifest-path ui/Cargo.toml --all --check
+
+          - name: "Format top-crates"
+            uses: actions-rs/cargo@v1
+            with:
+              command: fmt
+              args: --manifest-path top-crates/Cargo.toml --check
 
           - name: "Build backend"
             run: >-

--- a/top-crates/src/main.rs
+++ b/top-crates/src/main.rs
@@ -43,14 +43,15 @@ struct Profiles {
 }
 
 fn main() {
-    let mut f = File::open("crate-modifications.toml")
-        .expect("unable to open crate modifications file");
+    let mut f =
+        File::open("crate-modifications.toml").expect("unable to open crate modifications file");
 
     let mut d = Vec::new();
     f.read_to_end(&mut d)
         .expect("unable to read crate modifications file");
 
-    let modifications: Modifications = toml::from_slice(&d).expect("unable to parse crate modifications file");
+    let modifications: Modifications =
+        toml::from_slice(&d).expect("unable to parse crate modifications file");
 
     let (dependencies, infos) = rust_playground_top_crates::generate_info(&modifications);
 


### PR DESCRIPTION
I was touching `top-crates` and noticed that rustfmt makes a bunch of unrelated modifications. Formatting is enforced elsewhere in this codebase (for the `ui` crate) so I'm adding the same here for `top-crates`.