### PR TITLE
Omit build metadata from versions in generated Cargo.toml

### DIFF
--- a/top-crates/Cargo.lock
+++ b/top-crates/Cargo.lock
@@ -1153,6 +1153,7 @@ dependencies = [
  "cargo",
  "itertools",
  "reqwest",
+ "semver",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1227,9 +1228,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a41d061efea015927ac527063765e73601444cdc344ba855bc7bd44578b25e1c"
+checksum = "3d92beeab217753479be2f74e54187a6aed4c125ff0703a866c3147a02f0c6dd"
 dependencies = [
  "serde",
 ]

--- a/top-crates/Cargo.toml
+++ b/top-crates/Cargo.toml
@@ -12,6 +12,7 @@ repository = "https://github.com/integer32llc/rust-playground"
 cargo = "0.62.0"
 itertools = "0.10.0"
 reqwest = { version = "0.11.0", features = ["blocking"] }
+semver = { version = "1.0.11", features = ["serde"] }
 serde = "1.0.1"
 serde_derive = "1.0.1"
 serde_json = "1.0.0"


### PR DESCRIPTION
Prior to this, top-crates would serialize version reqs like this:

```toml
[dependencies.foo]
package = "foo"
version = "=1.2.3+whatever"
```

which would then stick a warning into the output every single time the playground compiles anything, whether or not that crate was ever used.

```console
warning: version requirement `=1.2.3+whatever` for dependency `foo` includes
semver metadata which will be ignored, removing the metadata is recommended
to avoid confusion
```

Note that we'll still keep the build metadata in generated crate-information.json, just not in Cargo.toml.