### PR TITLE
Bump typescript and prettier versions

### DIFF
--- a/ui/frontend/package.json
+++ b/ui/frontend/package.json
@@ -69,7 +69,7 @@
     "postcss-loader": "^7.0.0",
     "postcss-nesting": "^10.1.1",
     "postcss-simple-vars": "^6.0.3",
-    "prettier": "^2.2.1",
+    "prettier": "^2.7.1",
     "stylelint": "^14.2.0",
     "stylelint-config-css-modules": "^4.0.0",
     "stylelint-config-idiomatic-order": "^8.1.0",

--- a/ui/frontend/package.json
+++ b/ui/frontend/package.json
@@ -78,7 +78,7 @@
     "ts-essentials": "^9.0.0",
     "ts-jest": "^28.0.3",
     "ts-loader": "^9.2.3",
-    "typescript": "^4.2.2",
+    "typescript": "^4.7.4",
     "typescript-plugin-css-modules": "^3.2.0",
     "webpack": "^5.24.3",
     "webpack-cli": "^4.5.0"

--- a/ui/frontend/yarn.lock
+++ b/ui/frontend/yarn.lock
@@ -4948,10 +4948,10 @@ prelude-ls@^1.2.1:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
-prettier@^2.2.1:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.6.2.tgz#e26d71a18a74c3d0f0597f55f01fb6c06c206032"
-  integrity sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==
+prettier@^2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
+  integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
 
 pretty-error@^4.0.0:
   version "4.0.0"

--- a/ui/frontend/yarn.lock
+++ b/ui/frontend/yarn.lock
@@ -6169,10 +6169,10 @@ typescript-plugin-css-modules@^3.2.0:
     stylus "^0.54.8"
     tsconfig-paths "^3.9.0"
 
-typescript@^4.2.2:
-  version "4.7.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.2.tgz#1f9aa2ceb9af87cca227813b4310fff0b51593c4"
-  integrity sha512-Mamb1iX2FDUpcTRzltPxgWMKy3fhg0TN378ylbktPGPK/99KbDtMQ4W1hwgsbPAsG3a0xKa1vmw4VKZQbkvz5A==
+typescript@^4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 unbox-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This PR will upgrade TS to 4.7 and also prettier to 2.7.1 in order to support TS 4.7 syntax.

### Webpack Build Time in production mode

on my machine (macOS 11.6.7), it seems the upgrade can help webpack production build run faster 🤔 

#### Before

<details>

```
→ time yarn build:production
yarn run v1.22.17
$ webpack --progress --color --mode production
assets by path *.js 3.9 MiB
  assets by chunk 3.49 MiB (id hint: vendors)
    assets by status 3.33 MiB [big] 3 assets
    asset 35a974a68b896c5af82b.js 104 KiB [emitted] [immutable] [minimized] (name: ace-keybinding-vim) (id hint: vendors) 1 related asset
    asset fa85991cc5c4bf35e0fe.js 27 KiB [emitted] [immutable] [minimized] (name: ace-theme-ambiance) (id hint: vendors) 1 related asset
    asset f22d811d2ef88a1c1a3a.js 23.3 KiB [emitted] [immutable] [minimized] (name: ace-keybinding-emacs) (id hint: vendors) 1 related asset
  + 44 assets
assets by path *.css 230 KiB
  asset 591bff5e40bf8d934071.css 211 KiB [emitted] [immutable] (id hint: vendors) 1 related asset
  asset 58e1697ca2d3f597e29e.css 18 KiB [emitted] [immutable] (name: main) 1 related asset
  asset 04548a1d8c45ffc6c77c.css 1.77 KiB [emitted] [immutable] [from: node_modules/prismjs/themes/prism-okaidia.css] (auxiliary id hint: vendors) 1 related asset
assets by path ../ 627 bytes
  asset ../index.html 603 bytes [emitted] 1 related asset
  asset ../robots.txt 24 bytes [emitted] [from: robots.txt] [copied]
Entrypoint main [big] 487 KiB (1.77 KiB) = cddb41c5f0cfbdedc1b7.js 365 KiB 58e1697ca2d3f597e29e.css 18 KiB 1465e09c51853094f2cd.js 104 KiB 1 auxiliary asset
orphan modules 3.93 MiB (javascript) 975 bytes (runtime) [orphan] 729 modules
runtime modules 100 KiB 403 modules
built modules 8.63 MiB (javascript) 229 KiB (css/mini-extract) 1.77 KiB (asset) [built]
  javascript modules 8.63 MiB
    modules by path ./node_modules/ 8.43 MiB 791 modules
    modules by path ./editor/ 8.21 KiB 3 modules
    ./index.tsx + 99 modules 198 KiB [built] [code generated]
    ./util.inspect (ignored) 15 bytes [built] [code generated]
  css modules 229 KiB
    modules by path ./node_modules/ 217 KiB 71 modules
    modules by path ./*.css 10.7 KiB 21 modules
    modules by path ./Output/ 1.01 KiB 5 modules
    css ./node_modules/css-loader/dist/cjs.js??ruleSet[1].rules[2].oneOf[1].use[1]!./node_modules/postcss-loader/dist/cjs.js!./editor/Editor.module.css 194 bytes [built] [code generated]
  ./node_modules/prismjs/themes/prism-okaidia.css 42 bytes (javascript) 1.77 KiB (asset) [built] [code generated]

WARNING in asset size limit: The following asset(s) exceed the recommended size limit (244 KiB).
This can impact web performance.
Assets:
  591bff5e40bf8d934071.js (2.57 MiB)
  61aa61eb6a17f6d8b4e2.js (414 KiB)
  cddb41c5f0cfbdedc1b7.js (365 KiB)
  591bff5e40bf8d934071.js.gz (667 KiB)

WARNING in entrypoint size limit: The following entrypoint(s) combined asset size exceeds the recommended limit (244 KiB). This can impact web performance.
Entrypoints:
  main (487 KiB)
      cddb41c5f0cfbdedc1b7.js
      58e1697ca2d3f597e29e.css
      1465e09c51853094f2cd.js


webpack 5.72.1 compiled with 2 warnings in 42283 ms
✨  Done in 49.84s.
yarn build:production  99.87s user 8.79s system 217% cpu 50.031 total
```

</details>

#### After

<details>

```
→ time yarn build:production
yarn run v1.22.17
$ webpack --progress --color --mode production
assets by status 1.77 KiB [cached] 1 asset
assets by path *.js 3.9 MiB
  assets by chunk 3.49 MiB (id hint: vendors)
    assets by status 3.33 MiB [big] 3 assets
    asset 35a974a68b896c5af82b.js 104 KiB [emitted] [immutable] [minimized] (name: ace-keybinding-vim) (id hint: vendors) 1 related asset
    asset fa85991cc5c4bf35e0fe.js 27 KiB [emitted] [immutable] [minimized] (name: ace-theme-ambiance) (id hint: vendors) 1 related asset
    asset f22d811d2ef88a1c1a3a.js 23.3 KiB [emitted] [immutable] [minimized] (name: ace-keybinding-emacs) (id hint: vendors) 1 related asset
  + 44 assets
assets by path *.css 229 KiB
  asset 591bff5e40bf8d934071.css 211 KiB [emitted] [immutable] (id hint: vendors) 1 related asset
  asset 58e1697ca2d3f597e29e.css 18 KiB [emitted] [immutable] (name: main) 1 related asset
assets by path ../ 627 bytes
  asset ../index.html 603 bytes [emitted] 1 related asset
  asset ../robots.txt 24 bytes [compared for emit] [from: robots.txt] [copied]
Entrypoint main [big] 487 KiB (1.77 KiB) = cddb41c5f0cfbdedc1b7.js 365 KiB 58e1697ca2d3f597e29e.css 18 KiB 1465e09c51853094f2cd.js 104 KiB 1 auxiliary asset
orphan modules 3.93 MiB (javascript) 975 bytes (runtime) [orphan] 729 modules
runtime modules 100 KiB 403 modules
built modules 8.63 MiB (javascript) 229 KiB (css/mini-extract) 1.77 KiB (asset) [built]
  javascript modules 8.63 MiB
    modules by path ./node_modules/ 8.43 MiB 791 modules
    modules by path ./editor/ 8.21 KiB 3 modules
    ./index.tsx + 99 modules 198 KiB [built] [code generated]
    ./util.inspect (ignored) 15 bytes [built] [code generated]
  css modules 229 KiB
    modules by path ./node_modules/ 217 KiB 71 modules
    modules by path ./*.css 10.7 KiB 21 modules
    modules by path ./Output/ 1.01 KiB 5 modules
    css ./node_modules/css-loader/dist/cjs.js??ruleSet[1].rules[2].oneOf[1].use[1]!./node_modules/postcss-loader/dist/cjs.js!./editor/Editor.module.css 194 bytes [built] [code generated]
  ./node_modules/prismjs/themes/prism-okaidia.css 42 bytes (javascript) 1.77 KiB (asset) [built] [code generated]

WARNING in asset size limit: The following asset(s) exceed the recommended size limit (244 KiB).
This can impact web performance.
Assets:
  591bff5e40bf8d934071.js (2.57 MiB)
  61aa61eb6a17f6d8b4e2.js (414 KiB)
  cddb41c5f0cfbdedc1b7.js (365 KiB)
  591bff5e40bf8d934071.js.gz (667 KiB)

WARNING in entrypoint size limit: The following entrypoint(s) combined asset size exceeds the recommended limit (244 KiB). This can impact web performance.
Entrypoints:
  main (487 KiB)
      cddb41c5f0cfbdedc1b7.js
      58e1697ca2d3f597e29e.css
      1465e09c51853094f2cd.js


webpack 5.72.1 compiled with 2 warnings in 33422 ms
✨  Done in 39.26s.
yarn build:production  84.09s user 5.64s system 227% cpu 39.451 total
```

</details>