### PR TITLE
fix miri sysroot location

### DIFF
--- a/compiler/miri/cargo-miri-playground
+++ b/compiler/miri/cargo-miri-playground
@@ -2,6 +2,6 @@
 
 set -eu
 
-export MIRI_SYSROOT=~/.cache/miri/HOST
+export MIRI_SYSROOT=~/.cache/miri
 export MIRIFLAGS="-Zmiri-disable-isolation"
 exec cargo miri run


### PR DESCRIPTION
The miri sysroot moved, so this hard-coded location needs to be updated.