### PR TITLE
feat(ui/frontend): add shortcuts for tools

### DIFF
--- a/ui/frontend/Playground.tsx
+++ b/ui/frontend/Playground.tsx
@@ -112,10 +112,13 @@ const Playground: React.FC = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  useKeyDown(['Control', 'Alt', 'f'], handleRustFmt);
-  useKeyDown(['Control', 'Alt', 'c'], handleClippy);
-  useKeyDown(['Control', 'Alt', 'm'], handleMiri);
-  useKeyDown(['Control', 'Alt', 'e'], handleMacroExpansion);
+  const shortcutMap = new Map([
+    [['Control', 'Alt', 'f'], handleRustFmt],
+    [['Control', 'Alt', 'c'], handleClippy],
+    [['Control', 'Alt', 'm'], handleMiri],
+    [['Control', 'Alt', 'x'], handleMacroExpansion],
+  ]);
+  useKeyDown(shortcutMap);
 
   return (
     <>

--- a/ui/frontend/Playground.tsx
+++ b/ui/frontend/Playground.tsx
@@ -11,6 +11,8 @@ import { Orientation } from './types';
 import * as actions from './actions';
 
 import styles from './Playground.module.css';
+import { useKeyDown } from './hooks/shortcuts';
+import { useAppDispatch } from './configureStore';
 
 const TRACK_OPTION_NAME = {
   [Orientation.Horizontal]: 'rowGutters',
@@ -88,7 +90,32 @@ const ResizableArea: React.FC = () => {
 };
 
 const Playground: React.FC = () => {
-  const showNotifications = useSelector(selectors.anyNotificationsToShowSelector);
+  const showNotifications = useSelector(
+    selectors.anyNotificationsToShowSelector
+  );
+
+  const dispatch = useAppDispatch();
+  const handleRustFmt = useCallback((_event) => {
+    dispatch(actions.performFormat());
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  const handleClippy = useCallback((_event) => {
+    dispatch(actions.performClippy());
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  const handleMiri = useCallback((_event) => {
+    dispatch(actions.performMiri());
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  const handleMacroExpansion = useCallback((_event) => {
+    dispatch(actions.performMacroExpansion());
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useKeyDown(['Control', 'Alt', 'f'], handleRustFmt);
+  useKeyDown(['Control', 'Alt', 'c'], handleClippy);
+  useKeyDown(['Control', 'Alt', 'm'], handleMiri);
+  useKeyDown(['Control', 'Alt', 'e'], handleMacroExpansion);
 
   return (
     <>
@@ -96,7 +123,7 @@ const Playground: React.FC = () => {
         <Header />
         <ResizableArea />
       </div>
-      { showNotifications && <Notifications />}
+      {showNotifications && <Notifications />}
     </>
   );
 }

--- a/ui/frontend/ToolsMenu.module.css
+++ b/ui/frontend/ToolsMenu.module.css
@@ -1,0 +1,5 @@
+.shortcut {
+  float: right;
+  background-color: #a0ffa0;
+  border: 2px solid #a0ffa0;
+}

--- a/ui/frontend/ToolsMenu.tsx
+++ b/ui/frontend/ToolsMenu.tsx
@@ -9,6 +9,8 @@ import * as selectors from './selectors';
 import * as actions from './actions';
 import { useAppDispatch } from './configureStore';
 
+import styles from './ToolsMenu.module.css';
+
 interface ToolsMenuProps {
   close: () => void;
 }
@@ -46,18 +48,21 @@ const ToolsMenu: React.FC<ToolsMenuProps> = props => {
       <ButtonMenuItem
         name="Rustfmt"
         onClick={format}>
+        <span className={styles.shortcut}>⌘/Ctrl + Alt + f</span>
         <div>Format this code with Rustfmt.</div>
         <MenuAside>{rustfmtVersion} ({rustfmtVersionDetails})</MenuAside>
       </ButtonMenuItem>
       <ButtonMenuItem
         name="Clippy"
         onClick={clippy}>
+        <span className={styles.shortcut}>⌘/Ctrl + Alt + c</span>
         <div>Catch common mistakes and improve the code using the Clippy linter.</div>
         <MenuAside>{clippyVersion} ({clippyVersionDetails})</MenuAside>
       </ButtonMenuItem>
       <ButtonMenuItem
         name="Miri"
         onClick={miri}>
+        <span className={styles.shortcut}>⌘/Ctrl + Alt + m</span>
         <div>
           Execute this program in the Miri interpreter to detect certain
           cases of undefined behavior (like out-of-bounds memory access).
@@ -67,6 +72,7 @@ const ToolsMenu: React.FC<ToolsMenuProps> = props => {
       <ButtonMenuItem
         name="Expand macros"
         onClick={expandMacros}>
+        <span className={styles.shortcut}>⌘/Ctrl + Alt + x</span>
         <div>
           Expand macros in code using the nightly compiler.
         </div>

--- a/ui/frontend/hooks/shortcuts.tsx
+++ b/ui/frontend/hooks/shortcuts.tsx
@@ -1,0 +1,55 @@
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
+
+export const useKeyDown = (keys: string[], callback: Function, node = null) => {
+  const [currentShortcutKeys, setCurrentShortcutKeys] = useState<string[]>([]);
+
+  const callbackRef = useRef(callback);
+  useLayoutEffect(() => {
+    callbackRef.current = callback;
+  });
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      // If key is already depressed, return early
+      if (currentShortcutKeys.includes(event.key)) {
+        return;
+      }
+      const newShortcutKeys = currentShortcutKeys.concat([event.key]);
+      // Note: this implementation cares about order of keys pressed
+      if (
+        keys.length === newShortcutKeys.length &&
+        keys.every((val, i) => newShortcutKeys[i] === val)
+      ) {
+        callbackRef.current(event);
+      }
+      setCurrentShortcutKeys(newShortcutKeys);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [keys]
+  );
+
+  const handleKeyUp = (event: KeyboardEvent) => {
+    setCurrentShortcutKeys((prev) => {
+      const keyIndex = prev.indexOf(event.key);
+      if (keyIndex !== -1) {
+        return prev.slice(0, keyIndex).concat(prev.slice(keyIndex + 1));
+      }
+      return prev;
+    });
+  };
+
+  useEffect(() => {
+    // target is either the provided node or the whole document
+    const targetNode = node ?? document;
+    targetNode.addEventListener('keydown', handleKeyDown);
+    targetNode.addEventListener('keyup', handleKeyUp);
+    return () =>
+      targetNode && targetNode.removeEventListener('keydown', handleKeyDown);
+  }, [handleKeyDown, node]);
+};


### PR DESCRIPTION
Adds shortcuts to tools. Global event listener is added for the following keydown events:

| Keys | Result |
| ----- | ------- |
| `Ctrl + Alt + f` | Rust Fmt on the code |
| `Ctrl + Alt + m` | Miri |
| `Ctrl + Alt + x` | Macro Expansion |
| `Ctrl + Alt + c` | Clippy |

The above can easily be changed. However, certain combinations are reserved by different browsers.

<details>
  <summary>What this looks like</summary>

  I realise the background colour from the issue was probably for emphasis. So, am obviously happy to change/remove it.

  <img width="317" alt="image" src="https://user-images.githubusercontent.com/51722130/209454688-3ad87b3f-4ea7-4aca-914c-04d25c1f777e.png" />
</details>

Closes #844 

---

Aside: More ESLint/editor rules should be added, as I constantly needed to avoid saving with formatting.