### PR TITLE
Update address bar after saving Gist

### DIFF
--- a/tests/spec/features/navigation_spec.rb
+++ b/tests/spec/features/navigation_spec.rb
@@ -1,24 +1,10 @@
 require 'spec_helper'
 require 'support/editor'
+require 'support/matchers/be_at_url'
 require 'support/playground_actions'
 
 RSpec.feature "Navigating between pages", type: :feature, js: true do
   include PlaygroundActions
-
-  RSpec::Matchers.define :be_at_url do |path, query = {}|
-    match do |page|
-      uri = URI::parse(page.current_url)
-      expect(uri.path).to eql(path)
-
-      query = query.map { |k, v| [k.to_s, Array(v).map(&:to_s)] }.to_h
-      query_hash = CGI::parse(uri.query || '')
-      expect(query_hash).to include(query)
-    end
-
-    failure_message do |page|
-      "expected that #{page.current_url} would be #{path} with the query parameters #{query}"
-    end
-  end
 
   # This is kind of a test of the router library too, so if that ever
   # gets extracted, a chunk of these tests can be removed.

--- a/tests/spec/features/sharing_with_others_spec.rb
+++ b/tests/spec/features/sharing_with_others_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'support/editor'
+require 'support/matchers/be_at_url'
 require 'support/playground_actions'
 
 RSpec.feature "Sharing the code with others", type: :feature, js: true do
@@ -22,6 +23,10 @@ RSpec.feature "Sharing the code with others", type: :feature, js: true do
     perma_link = find_link("Permalink to the playground")[:href]
     direct_link = find_link("Direct link to the gist")[:href]
     urlo_link = find_link("Open a new thread in the Rust user forum")[:href]
+
+    # Have we automatically added the gist to our URL?
+    gist_id = Addressable::URI.parse(perma_link).query_values['gist']
+    expect(page).to be_at_url('/', gist: gist_id)
 
     # Navigate away so we can tell that we go back to the same page
     visit 'about:blank'

--- a/tests/spec/support/matchers/be_at_url.rb
+++ b/tests/spec/support/matchers/be_at_url.rb
@@ -1,0 +1,14 @@
+RSpec::Matchers.define :be_at_url do |path, query = {}|
+  match do |page|
+    uri = URI::parse(page.current_url)
+    expect(uri.path).to eql(path)
+
+    query = query.map { |k, v| [k.to_s, Array(v).map(&:to_s)] }.to_h
+    query_hash = CGI::parse(uri.query || '')
+    expect(query_hash).to include(query)
+  end
+
+  failure_message do |page|
+    "expected that #{page.current_url} would be #{path} with the query parameters #{query}"
+  end
+end

--- a/ui/frontend/Output/Gist.tsx
+++ b/ui/frontend/Output/Gist.tsx
@@ -7,6 +7,7 @@ import { State } from '../reducers';
 import * as selectors from '../selectors';
 
 import Loader from './Loader';
+import Section from './Section';
 
 import styles from './Gist.module.css';
 
@@ -58,6 +59,7 @@ const Links: React.FC = () => {
   const gistUrl = useSelector((state: State) => state.output.gist.url);
   const permalink = useSelector(selectors.permalinkSelector);
   const urloUrl = useSelector(selectors.urloUrlSelector);
+  const textChanged = useSelector(selectors.textChangedSinceShareSelector);
 
   return (
     <Fragment>
@@ -65,6 +67,9 @@ const Links: React.FC = () => {
       { gistUrl ? <Copied href={gistUrl}>Direct link to the gist</Copied> : null }
       <Copied href={codeUrl}>Embedded code in link</Copied>
       <NewWindow href={urloUrl}>Open a new thread in the Rust user forum</NewWindow>
+      {textChanged ? <Section kind="warning" label="Code changed">
+        Source code has been changed since gist was saved
+      </Section>: null }
     </Fragment>
   );
 };

--- a/ui/frontend/Router.tsx
+++ b/ui/frontend/Router.tsx
@@ -20,19 +20,29 @@ interface Substate {
     channel: Channel;
     mode: Mode;
     edition: Edition;
+  };
+  output: {
+    gist: {
+      id?: string;
+    }
   }
 }
 
-const stateSelector = ({ page, configuration: { channel, mode, edition } }: State): Substate => ({
+const stateSelector = ({ page, configuration: { channel, mode, edition}, output }: State): Substate => ({
   page,
   configuration: {
     channel,
     mode,
     edition,
   },
+  output: {
+    gist: {
+      id: output.gist.id,
+    },
+  },
 });
 
-const stateToLocation = ({ page, configuration }: Substate): Partial<Path> => {
+const stateToLocation = ({ page, configuration, output }: Substate): Partial<Path> => {
   switch (page) {
     case 'help': {
       return {
@@ -45,6 +55,7 @@ const stateToLocation = ({ page, configuration }: Substate): Partial<Path> => {
         version: configuration.channel,
         mode: configuration.mode,
         edition: configuration.edition,
+        gist: output.gist.id,
       };
       return {
         pathname: `/?${qs.stringify(query)}`,

--- a/ui/frontend/selectors/index.ts
+++ b/ui/frontend/selectors/index.ts
@@ -205,6 +205,11 @@ export const permalinkSelector = createSelector(
   },
 );
 
+export const textChangedSinceShareSelector = createSelector(
+  codeSelector, gistSelector,
+  (code, gist) => code !== gist.code
+)
+
 const codeBlock = (code: string, language = '') =>
   '```' + language + `\n${code}\n` + '```';
 


### PR DESCRIPTION
After we've clicked 'Share' and a Gist has been created, update the address bar with the permalink to the shared playground.

I'm not very familiar with React, so apologies if this isn't the idiomatic way to do this.