### PR TITLE
update error-index hyperlinks

### DIFF
--- a/tests/spec/features/highlighting_error_output_spec.rb
+++ b/tests/spec/features/highlighting_error_output_spec.rb
@@ -30,7 +30,7 @@ RSpec.feature "Highlighting the output", type: :feature, js: true do
 
   scenario "error codes link to the error page" do
     within(:output, :stderr) do
-      expect(page).to have_link('E0107', href: /error-index.html#E0107/)
+      expect(page).to have_link('E0107', href: %r{/error_codes/E0107.html})
     end
   end
 

--- a/ui/frontend/highlighting.ts
+++ b/ui/frontend/highlighting.ts
@@ -69,7 +69,7 @@ export function configureRustErrors({
       if (errorMatch) {
         const [errorCode] = errorMatch;
         env.tag = 'a';
-        env.attributes.href = `https://doc.rust-lang.org/${getChannel()}/error-index.html#${errorCode}`;
+        env.attributes.href = `https://doc.rust-lang.org/${getChannel()}/error_codes/${errorCode}.html`;
         env.attributes.target = '_blank';
       }
     }


### PR DESCRIPTION
This updates the hyperlinks for error codes to point to the new error index locations (as updated in rust-lang/rust #100922). For example, what used to link to `https://doc.rust-lang.org/stable/error-index.html#E0005` will now link to `https://doc.rust-lang.org/stable/error_codes/E0005.html`. Currently, a redirect makes this work fine, but it's probably best to use the new locations.