### PR TITLE
env CARGO_TERM_COLOR set to always

### DIFF
--- a/compiler/base/orchestrator/src/coordinator.rs
+++ b/compiler/base/orchestrator/src/coordinator.rs
@@ -533,6 +533,8 @@ impl LowerRequest for CompileRequest {
             envs.extend(kvs!("RUST_BACKTRACE" => "1"));
         }
 
+        envs.insert("CARGO_TERM_COLOR".to_owned(), "always".to_owned());
+
         ExecuteCommandRequest {
             cmd: "cargo".to_owned(),
             args: args.into_iter().map(|s| s.to_owned()).collect(),


### PR DESCRIPTION
This PR set the env CARGO_TERM_COLOR to always when calling the compiler.

It will allow output to be parsed to the original colors.

[doc](https://doc.rust-lang.org/cargo/reference/config.html#termcolor)


Related Issues
https://github.com/rust-lang/rust-playground/issues/879
https://github.com/rust-lang/rust-playground/issues/900