### PR TITLE
Use same column resize handle as rustdoc and mdbook

### DIFF
--- a/ui/frontend/Playground.module.css
+++ b/ui/frontend/Playground.module.css
@@ -43,7 +43,27 @@
 
 .splitRowsGutterHandle {
   transform: rotate(90deg);
+}
+
+.splitColumnsGutterHandle, .splitRowsGutterHandle {
   pointer-events: none;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.splitColumnsGutterHandle::before, .splitRowsGutterHandle::before {
+  content: "";
+  width: 2px;
+  height: 12px;
+  border-left: dotted 2px currentColor;
+}
+
+.splitColumnsGutterHandle::after, .splitRowsGutterHandle::after {
+  content: "";
+  width: 2px;
+  height: 16px;
+  border-right: dotted 2px currentColor;
 }
 
 .splitColumnsGutter {

--- a/ui/frontend/Playground.tsx
+++ b/ui/frontend/Playground.tsx
@@ -28,7 +28,7 @@ const UNFOCUSED_GRID_STYLE = {
 
 const HANDLE_STYLES = {
   [Orientation.Horizontal]: [styles.splitRowsGutter, styles.splitRowsGutterHandle],
-  [Orientation.Vertical]: [styles.splitColumnsGutter, ''],
+  [Orientation.Vertical]: [styles.splitColumnsGutter, styles.splitColumnsGutterHandle],
 }
 
 // We drop down to lower-level split-grid code and use some hooks
@@ -72,7 +72,7 @@ const ResizableArea: React.FC = () => {
       <div className={styles.editor}><Editor /></div>
       { isFocused &&
         <div ref={dragHandle} className={handleOuterStyle}>
-          <span className={handleInnerStyle}>⣿</span>
+          <span className={handleInnerStyle}></span>
         </div>
       }
       { somethingToShow && <div className={styles.output}><Output /></div>}


### PR DESCRIPTION
<table><thead><tr><th>Before<th>After</tr></thead>
<tbody>
<tr>
<td><img width="2288" height="1284" alt="image" src="https://github.com/user-attachments/assets/83735fb3-43ea-46c2-ba5c-031aa0f6c919" />
<td><img width="2288" height="1284" alt="image" src="https://github.com/user-attachments/assets/52fce7e4-b54a-400b-86f1-21e272a96287" />
<tr>
<td>
<img width="2288" height="1284" alt="image" src="https://github.com/user-attachments/assets/3009472d-f245-40cb-a983-b6cb65e31426" />
<td>
<img width="2288" height="1284" alt="image" src="https://github.com/user-attachments/assets/a48fab1f-5748-4be9-a0f4-afcfda695f86" />
<tr>
<td>
<img width="2288" height="1284" alt="image" src="https://github.com/user-attachments/assets/c57b254f-836a-45f4-927e-98aca1ff8f40" />
<td>
<img width="2288" height="1284" alt="image" src="https://github.com/user-attachments/assets/5232deeb-b953-4f33-b75b-40c0230a6d25" />
</tr>
</tbody>
</table>

Follow up: https://github.com/rust-lang/rust/pull/139562