### PR TITLE
Rewrite Docker aspects of CI

### DIFF
--- a/.github/actions/build-and-push-image/action.yml
+++ b/.github/actions/build-and-push-image/action.yml
@@ -1,0 +1,26 @@
+name: "Build and push image"
+description: "Build and push image"
+
+inputs:
+  channel:
+    description: "The Rust channel to build"
+    required: true
+
+  tags:
+    description: "The newline-separated tags to create"
+    required: true
+
+runs:
+  using: "composite"
+
+  steps:
+    - uses: docker/build-push-action@v6
+      with:
+        context: compiler/base/
+        file: compiler/base/Dockerfile
+        build-args: |-
+          channel=${{ inputs.channel }}
+        push: true
+        tags: ${{ inputs.tags }}
+        cache-from: type=gha,scope=${{ inputs.channel }}
+        cache-to: type=gha,scope=${{ inputs.channel }},mode=max

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ env:
   GH_CONTAINER_REGISTRY_USERNAME: shepmaster
   AWS_ACCESS_KEY_ID: AKIAWESVHZ3JQAY5NM5K
 jobs:
-  build_compiler_containers:
-    name: Build ${{ matrix.channel }} compiler container
+  build_compiler_images:
+    name: Build provisional ${{ matrix.channel }} image
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -24,7 +24,8 @@ jobs:
         - nightly
     if: 'github.event_name == ''push'' || contains(github.event.pull_request.labels.*.name, ''CI: approved'')'
     env:
-      IMAGE_NAME: ghcr.io/integer32llc/rust-playground-ci-rust-${{ matrix.channel }}
+      GHCR_IMAGE_NAME: ghcr.io/integer32llc/rust-playground-ci-rust-${{ matrix.channel }}
+      DOCKER_HUB_IMAGE_NAME: shepmaster/rust-${{ matrix.channel }}
     steps:
     - name: Checkout code
       uses: actions/checkout@v6
@@ -38,16 +39,11 @@ jobs:
         registry: ghcr.io
         username: "${{ env.GH_CONTAINER_REGISTRY_USERNAME }}"
         password: "${{ secrets.GH_CONTAINER_REGISTRY_TOKEN }}"
-    - name: Build and push container
-      uses: docker/build-push-action@v6
+    - name: Build provisional ${{ matrix.channel }} image
+      uses: "./.github/actions/build-and-push-image"
       with:
-        context: compiler/base/
-        file: compiler/base/Dockerfile
-        build-args: channel=${{ matrix.channel }}
-        push: true
-        tags: "${{ env.IMAGE_NAME }}:${{ github.run_id }}"
-        cache-from: type=gha,scope=${{ matrix.channel }}
-        cache-to: type=gha,scope=${{ matrix.channel }},mode=max
+        channel: "${{ matrix.channel }}"
+        tags: "${{ env.GHCR_IMAGE_NAME }}:${{ github.run_id }}"
   build_backend:
     name: Build backend
     runs-on: ubuntu-latest
@@ -130,7 +126,7 @@ jobs:
     runs-on: ubuntu-latest
     if: 'github.event_name == ''push'' || contains(github.event.pull_request.labels.*.name, ''CI: approved'')'
     needs:
-    - build_compiler_containers
+    - build_compiler_images
     - build_backend
     - build_frontend
     defaults:
@@ -158,13 +154,11 @@ jobs:
         gem install bundler
         bundle config path vendor/bundle
         bundle install --jobs 4 --retry 3
-    - name: Pull containers
+    - name: Pull images
       run: echo ghcr.io/integer32llc/rust-playground-ci-rust-{stable,beta,nightly}:${{ github.run_id }} | xargs -n1 docker pull --platform linux/amd64
-    - name: Rename containers
+    - name: Rename images
       run: |-
         for c in stable beta nightly; do
-          docker tag ghcr.io/integer32llc/rust-playground-ci-rust-$c:${{ github.run_id }} ghcr.io/integer32llc/rust-playground-ci-rust-$c
-          docker tag ghcr.io/integer32llc/rust-playground-ci-rust-$c:${{ github.run_id }} shepmaster/rust-$c
           docker tag ghcr.io/integer32llc/rust-playground-ci-rust-$c:${{ github.run_id }} rust-$c
         done
     - name: Download backend
@@ -209,34 +203,6 @@ jobs:
       contents: read
       id-token: write
     steps:
-    - name: Login to GitHub Container Registry
-      uses: docker/login-action@v3
-      with:
-        registry: ghcr.io
-        username: "${{ env.GH_CONTAINER_REGISTRY_USERNAME }}"
-        password: "${{ secrets.GH_CONTAINER_REGISTRY_TOKEN }}"
-    - name: Login to Docker Hub
-      uses: docker/login-action@v3
-      with:
-        username: "${{ env.DOCKER_HUB_USERNAME }}"
-        password: "${{ secrets.DOCKER_HUB_TOKEN }}"
-    - name: Recover disk space
-      run: sudo rm -rf /usr/local/lib/android
-    - name: Pull containers
-      run: echo ghcr.io/integer32llc/rust-playground-ci-rust-{stable,beta,nightly}:${{ github.run_id }} | xargs -n1 docker pull --platform linux/amd64
-    - name: Rename containers
-      run: |-
-        for c in stable beta nightly; do
-          docker tag ghcr.io/integer32llc/rust-playground-ci-rust-$c:${{ github.run_id }} ghcr.io/integer32llc/rust-playground-ci-rust-$c
-          docker tag ghcr.io/integer32llc/rust-playground-ci-rust-$c:${{ github.run_id }} shepmaster/rust-$c
-          docker tag ghcr.io/integer32llc/rust-playground-ci-rust-$c:${{ github.run_id }} rust-$c
-        done
-    - name: Push containers
-      run: |-
-        for c in stable beta nightly; do
-          docker push --platform linux/amd64 ghcr.io/integer32llc/rust-playground-ci-rust-$c
-          docker push --platform linux/amd64 shepmaster/rust-$c
-        done
     - name: Download backend
       uses: actions/download-artifact@v7
       with:
@@ -267,3 +233,37 @@ jobs:
       run: aws s3 cp server/ui s3://rust-playground-artifacts
     - name: Push frontend (rust-lang)
       run: aws s3 sync server/build/ s3://rust-playground-artifacts/build
+  release_docker_artifacts:
+    name: Release ${{ matrix.channel }} image
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        channel:
+        - stable
+        - beta
+        - nightly
+    needs:
+    - run_integration_tests
+    env:
+      GHCR_IMAGE_NAME: ghcr.io/integer32llc/rust-playground-ci-rust-${{ matrix.channel }}
+      DOCKER_HUB_IMAGE_NAME: shepmaster/rust-${{ matrix.channel }}
+    if: github.event_name == 'push' && github.event.ref == 'refs/heads/main'
+    steps:
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: "${{ env.GH_CONTAINER_REGISTRY_USERNAME }}"
+        password: "${{ secrets.GH_CONTAINER_REGISTRY_TOKEN }}"
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: "${{ env.DOCKER_HUB_USERNAME }}"
+        password: "${{ secrets.DOCKER_HUB_TOKEN }}"
+    - name: Release ${{ matrix.channel }} image
+      uses: "./.github/actions/build-and-push-image"
+      with:
+        channel: "${{ matrix.channel }}"
+        tags: |-
+          ${{ env.GHCR_IMAGE_NAME }}
+          ${{ env.DOCKER_HUB_IMAGE_NAME }}

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -10,8 +10,8 @@ env:
   GH_CONTAINER_REGISTRY_USERNAME: shepmaster
   AWS_ACCESS_KEY_ID: AKIAWESVHZ3JQAY5NM5K
 jobs:
-  build_compiler_containers:
-    name: Build ${{ matrix.channel }} compiler container
+  build_compiler_images:
+    name: Release ${{ matrix.channel }} image
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -20,7 +20,7 @@ jobs:
         - beta
         - nightly
     env:
-      IMAGE_NAME: ghcr.io/integer32llc/rust-playground-ci-rust-${{ matrix.channel }}
+      GHCR_IMAGE_NAME: ghcr.io/integer32llc/rust-playground-ci-rust-${{ matrix.channel }}
       DOCKER_HUB_IMAGE_NAME: shepmaster/rust-${{ matrix.channel }}
     continue-on-error: true
     steps:
@@ -39,23 +39,10 @@ jobs:
       with:
         username: "${{ env.DOCKER_HUB_USERNAME }}"
         password: "${{ secrets.DOCKER_HUB_TOKEN }}"
-    - name: Build and push container
-      uses: docker/build-push-action@v6
+    - name: Release ${{ matrix.channel }} image
+      uses: "./.github/actions/build-and-push-image"
       with:
-        context: compiler/base/
-        file: compiler/base/Dockerfile
-        build-args: channel=${{ matrix.channel }}
-        push: true
-        tags: "${{ env.IMAGE_NAME }}:${{ github.run_id }}"
-        cache-from: type=gha,scope=${{ matrix.channel }}
-        cache-to: type=gha,scope=${{ matrix.channel }},mode=max
-    - name: Pull container
-      run: docker pull --platform linux/amd64 ${{ env.IMAGE_NAME }}:${{ github.run_id }}
-    - name: Rename container
-      run: |-
-        docker tag ${{ env.IMAGE_NAME }}:${{ github.run_id }} ${{ env.IMAGE_NAME }}
-        docker tag ${{ env.IMAGE_NAME }}:${{ github.run_id }} ${{ env.DOCKER_HUB_IMAGE_NAME }}
-    - name: Push container
-      run: |-
-        docker push --platform linux/amd64 ${{ env.IMAGE_NAME }}
-        docker push --platform linux/amd64 ${{ env.DOCKER_HUB_IMAGE_NAME }}
+        channel: "${{ matrix.channel }}"
+        tags: |-
+          ${{ env.GHCR_IMAGE_NAME }}
+          ${{ env.DOCKER_HUB_IMAGE_NAME }}

--- a/ci/workflows.yml
+++ b/ci/workflows.yml
@@ -41,61 +41,16 @@ components:
         username: ${{ env.DOCKER_HUB_USERNAME }}
         password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
-  - build_compiler_containers_job: &build_compiler_containers_job
-      name: "Build ${{ matrix.channel }} compiler container"
+  - each_channel_matrix_job: &each_channel_matrix_job
       runs-on: ubuntu-latest
 
       strategy:
         matrix:
           channel: [stable, beta, nightly]
 
-  - build_compiler_containers_job_env: &build_compiler_containers_job_env
-      IMAGE_NAME: ghcr.io/integer32llc/rust-playground-ci-rust-${{ matrix.channel }}
-
-  - build_compiler_containers: &build_compiler_containers
-      name: "Build and push container"
-      uses: docker/build-push-action@v6
-      with:
-        context: compiler/base/
-        file: compiler/base/Dockerfile
-        build-args: |-
-          channel=${{ matrix.channel }}
-        push: true
-        tags: |-
-          ${{ env.IMAGE_NAME }}:${{ github.run_id }}
-        cache-from: type=gha,scope=${{ matrix.channel }}
-        cache-to: type=gha,scope=${{ matrix.channel }},mode=max
-
-  - pull_containers: &pull_containers
-      name: "Pull containers"
-      run: |-
-        echo ghcr.io/integer32llc/rust-playground-ci-rust-{stable,beta,nightly}:${{ github.run_id }} | xargs -n1 docker pull --platform linux/amd64
-
-  - rename_all_containers: &rename_all_containers
-      name: "Rename containers"
-      run: |-
-        for c in stable beta nightly; do
-          docker tag ghcr.io/integer32llc/rust-playground-ci-rust-$c:${{ github.run_id }} ghcr.io/integer32llc/rust-playground-ci-rust-$c
-          docker tag ghcr.io/integer32llc/rust-playground-ci-rust-$c:${{ github.run_id }} shepmaster/rust-$c
-          docker tag ghcr.io/integer32llc/rust-playground-ci-rust-$c:${{ github.run_id }} rust-$c
-        done
-
-  - pull_current_container: &pull_current_container
-      name: "Pull container"
-      run: |-
-        docker pull --platform linux/amd64 ${{ env.IMAGE_NAME }}:${{ github.run_id }}
-
-  - rename_current_container: &rename_current_container
-      name: "Rename container"
-      run: |-
-        docker tag ${{ env.IMAGE_NAME }}:${{ github.run_id }} ${{ env.IMAGE_NAME }}
-        docker tag ${{ env.IMAGE_NAME }}:${{ github.run_id }} ${{ env.DOCKER_HUB_IMAGE_NAME }}
-
-  - push_current_container: &push_current_container
-      name: "Push container"
-      run: |-
-        docker push --platform linux/amd64 ${{ env.IMAGE_NAME }}
-        docker push --platform linux/amd64 ${{ env.DOCKER_HUB_IMAGE_NAME }}
+  - image_names_env: &image_names_env
+      GHCR_IMAGE_NAME: ghcr.io/integer32llc/rust-playground-ci-rust-${{ matrix.channel }}
+      DOCKER_HUB_IMAGE_NAME: shepmaster/rust-${{ matrix.channel }}
 
 workflows:
   ci:
@@ -111,17 +66,24 @@ workflows:
     <<: *global_env
 
     jobs:
-      build_compiler_containers:
-        <<: *build_compiler_containers_job
+      build_compiler_images:
+        name: "Build provisional ${{ matrix.channel }} image"
+        <<: *each_channel_matrix_job
         if: "github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'CI: approved')"
         env:
-          <<: *build_compiler_containers_job_env
+          <<: *image_names_env
 
         steps:
           - *checkout_pr
           - *docker_buildx
           - *login_ghcr
-          - *build_compiler_containers
+
+          - name: "Build provisional ${{ matrix.channel }} image"
+            uses: ./.github/actions/build-and-push-image
+            with:
+              channel: ${{ matrix.channel }}
+              tags: |-
+                ${{ env.GHCR_IMAGE_NAME }}:${{ github.run_id }}
 
       build_backend:
         name: "Build backend"
@@ -224,7 +186,7 @@ workflows:
         runs-on: ubuntu-latest
         if: "github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'CI: approved')"
         needs:
-          - build_compiler_containers
+          - build_compiler_images
           - build_backend
           - build_frontend
 
@@ -256,8 +218,15 @@ workflows:
               bundle config path vendor/bundle
               bundle install --jobs 4 --retry 3
 
-          - *pull_containers
-          - *rename_all_containers
+          - name: "Pull images"
+            run: |-
+              echo ghcr.io/integer32llc/rust-playground-ci-rust-{stable,beta,nightly}:${{ github.run_id }} | xargs -n1 docker pull --platform linux/amd64
+
+          - name: "Rename images"
+            run: |-
+              for c in stable beta nightly; do
+                docker tag ghcr.io/integer32llc/rust-playground-ci-rust-$c:${{ github.run_id }} rust-$c
+              done
 
           - name: "Download backend"
             uses: actions/download-artifact@v7
@@ -310,21 +279,6 @@ workflows:
           id-token: write
 
         steps:
-          - *login_ghcr
-          - *login_docker_hub
-
-          - *recover_disk_space
-
-          - *pull_containers
-          - *rename_all_containers
-
-          - name: "Push containers"
-            run: |-
-              for c in stable beta nightly; do
-                docker push --platform linux/amd64 ghcr.io/integer32llc/rust-playground-ci-rust-$c
-                docker push --platform linux/amd64 shepmaster/rust-$c
-              done
-
           - name: "Download backend"
             uses: actions/download-artifact@v7
             with:
@@ -367,6 +321,26 @@ workflows:
             run: |-
               aws s3 sync server/build/ s3://rust-playground-artifacts/build
 
+      release_docker_artifacts:
+        name: "Release ${{ matrix.channel }} image"
+        <<: *each_channel_matrix_job
+        needs:
+          - run_integration_tests
+        env:
+          <<: *image_names_env
+        if: github.event_name == 'push' && github.event.ref == 'refs/heads/main'
+
+        steps:
+          - *login_ghcr
+          - *login_docker_hub
+
+          - name: "Release ${{ matrix.channel }} image"
+            uses: ./.github/actions/build-and-push-image
+            with:
+              channel: ${{ matrix.channel }}
+              tags: |-
+                ${{ env.GHCR_IMAGE_NAME }}
+                ${{ env.DOCKER_HUB_IMAGE_NAME }}
 
   cron:
     name: "Scheduled rebuild"
@@ -380,11 +354,12 @@ workflows:
     <<: *global_env
 
     jobs:
-      build_compiler_containers:
-        <<: *build_compiler_containers_job
+      build_compiler_images:
+        name: "Release ${{ matrix.channel }} image"
+        <<: *each_channel_matrix_job
         env:
-          <<: *build_compiler_containers_job_env
-          DOCKER_HUB_IMAGE_NAME: shepmaster/rust-${{ matrix.channel }}
+          <<: *image_names_env
+
         continue-on-error: true
 
         steps:
@@ -392,8 +367,11 @@ workflows:
           - *docker_buildx
           - *login_ghcr
           - *login_docker_hub
-          - *build_compiler_containers
 
-          - *pull_current_container
-          - *rename_current_container
-          - *push_current_container
+          - name: "Release ${{ matrix.channel }} image"
+            uses: ./.github/actions/build-and-push-image
+            with:
+              channel: ${{ matrix.channel }}
+              tags: |-
+                ${{ env.GHCR_IMAGE_NAME }}
+                ${{ env.DOCKER_HUB_IMAGE_NAME }}


### PR DESCRIPTION
A recent [GHA change][] updated to Docker 29, which causes build failures when we download / retag / push the image:

```
image with reference ghcr.io/integer32llc/rust-playground-ci-rust-beta:latest was found but does not provide the specified platform (linux/amd64)
```

I don't actually know what the deal is here, but I see that Docker 29 made changes to default container formats and started pushing multiple aspects of the image, including some attestation metadata as the platform `unknown/unknown`.

My suspicion is that GHCR does not support this fully, so when we pull and push, something is lost and it's trying to push the attestation metadata which fails.

To work around this, we can change the build process so that we always use `docker/build-push-action`, which does *something* different and works. We rely on the build caching so that "rebuilding" in multiple jobs is still fast.

[GHA change]: https://github.com/actions/runner-images/issues/13474