### PR TITLE
Allow the output area to shrink to zero height

### DIFF
--- a/ui/frontend/Playground.module.css
+++ b/ui/frontend/Playground.module.css
@@ -74,6 +74,7 @@
 }
 
 .output {
+  composes: -autoSize from './shared.module.css';
   grid-area: ooo;
 }
 


### PR DESCRIPTION
This was lost in the resizing refactor. Without it, the output can cause a scrollbar to appear on the whole page.

The previous fix (e8644dcf971ee880bdbc089937a0e1a7dfd44c71) applied to the entire playground container and worked when the editor was stacked above the output. This change is needed for when the output is side-by-side with the editor.