### PR TITLE
Add a custom negative matcher to speed up tests

### DIFF
--- a/tests/spec/features/reset_configuration_spec.rb
+++ b/tests/spec/features/reset_configuration_spec.rb
@@ -2,6 +2,7 @@ require 'json'
 
 require 'spec_helper'
 require 'support/editor'
+require 'support/matchers/editor'
 require 'support/playground_actions'
 
 RSpec.feature "Resetting the configuration to defaults", type: :feature, js: true do

--- a/tests/spec/support/editor.rb
+++ b/tests/spec/support/editor.rb
@@ -16,6 +16,10 @@ class Editor
     page.has_css? '.ace_line', text: text
   end
 
+  def has_no_line?(text)
+    page.has_no_css? '.ace_line', text: text
+  end
+
   def has_highlighted_text?(text)
     page.within('.ace_text-input', visible: :any) do
       selected = page.evaluate_script <<~JS

--- a/tests/spec/support/matchers/editor.rb
+++ b/tests/spec/support/matchers/editor.rb
@@ -1,0 +1,13 @@
+RSpec::Matchers.define :have_line do |text|
+  match do |editor|
+    editor.has_line?(text)
+  end
+
+  match_when_negated do |editor|
+    editor.has_no_line?(text)
+  end
+
+  description do
+    "have line #{text.inspect}"
+  end
+end


### PR DESCRIPTION
Without this, we spend the entire waiting time looking for the line to appear, and then negate that result.