### PR TITLE
Add some text when JS is disabled

### DIFF
--- a/ui/frontend/index.ejs
+++ b/ui/frontend/index.ejs
@@ -10,6 +10,9 @@
   </head>
   <main>
     <body>
+      <noscript>
+        <p style="display:flex;justify-content: center;">The Rust Playground requires JavaScript to be enabled.</p>
+      </noscript>
       <div id="playground"></div>
     </body>
   </main>


### PR DESCRIPTION
Currently, when JS disabled when we arrive on `play.rust-lang.org`, we just have an empty page. With this PR, when JS is disabled, it looks like this:

<img width="676" height="313" alt="image" src="https://github.com/user-attachments/assets/8fdaf2b7-5dbd-4331-be54-b06e7444608c" />

I made it very simple to convey the needed information, but I can add more content if you think it's needed.