### PR TITLE
Ignore main functions inside block comments

### DIFF
--- a/ui/frontend/selectors/index.spec.ts
+++ b/ui/frontend/selectors/index.spec.ts
@@ -59,10 +59,6 @@ describe('checking for a main function', () => {
     expect(hasMainFunction('/* fn hidden() {} */\nfn main() {}')).toBe(true);
   });
 
-  test('a main inside nested block comments does not count', () => {
-    expect(hasMainFunction('/* outer\n/* inner */\nfn main() {}\n*/')).toBe(false);
-  });
-
   test('block comment markers in strings do not hide a main', () => {
     expect(hasMainFunction('const marker: &str = "/*";\nfn main() {}')).toBe(true);
   });

--- a/ui/frontend/selectors/index.spec.ts
+++ b/ui/frontend/selectors/index.spec.ts
@@ -59,6 +59,10 @@ describe('checking for a main function', () => {
     expect(hasMainFunction('/* fn hidden() {} */\nfn main() {}')).toBe(true);
   });
 
+  test('a main inside a block comment after code does not count', () => {
+    expect(hasMainFunction('const X: () = (); /*\nfn main() {}\n*/')).toBe(false);
+  });
+
   test('block comment markers in strings do not hide a main', () => {
     expect(hasMainFunction('const marker: &str = "/*";\nfn main() {}')).toBe(true);
     expect(hasMainFunction('const marker: &str = "line\n/*\ntext";\nfn main() {}')).toBe(true);

--- a/ui/frontend/selectors/index.spec.ts
+++ b/ui/frontend/selectors/index.spec.ts
@@ -61,10 +61,16 @@ describe('checking for a main function', () => {
 
   test('block comment markers in strings do not hide a main', () => {
     expect(hasMainFunction('const marker: &str = "/*";\nfn main() {}')).toBe(true);
+    expect(hasMainFunction('const marker: &str = "line\n/*\ntext";\nfn main() {}')).toBe(true);
   });
 
   test('block comment markers in raw strings do not hide a main', () => {
     expect(hasMainFunction('const marker: &str = r#"/*"#;\nfn main() {}')).toBe(true);
+    expect(hasMainFunction('const marker: &str = r#"line\n/*\ntext"#;\nfn main() {}')).toBe(true);
+  });
+
+  test('block comment markers in line comments do not hide a main', () => {
+    expect(hasMainFunction('// /*\nfn main() {}')).toBe(true);
   });
 
   test('a function with the substring main does not count', () => {

--- a/ui/frontend/selectors/index.spec.ts
+++ b/ui/frontend/selectors/index.spec.ts
@@ -47,6 +47,30 @@ describe('checking for a main function', () => {
     expect(hasMainFunction('/* fn main()')).toBe(false);
   });
 
+  test('a main inside a multiline block comment does not count', () => {
+    expect(hasMainFunction('/*\nfn main() {}\n*/')).toBe(false);
+  });
+
+  test('a main inside an unclosed block comment does not count', () => {
+    expect(hasMainFunction('/*\nfn main() {}')).toBe(false);
+  });
+
+  test('a main after a multiline block comment counts', () => {
+    expect(hasMainFunction('/* fn hidden() {} */\nfn main() {}')).toBe(true);
+  });
+
+  test('a main inside nested block comments does not count', () => {
+    expect(hasMainFunction('/* outer\n/* inner */\nfn main() {}\n*/')).toBe(false);
+  });
+
+  test('block comment markers in strings do not hide a main', () => {
+    expect(hasMainFunction('const marker: &str = "/*";\nfn main() {}')).toBe(true);
+  });
+
+  test('block comment markers in raw strings do not hide a main', () => {
+    expect(hasMainFunction('const marker: &str = r#"/*"#;\nfn main() {}')).toBe(true);
+  });
+
   test('a function with the substring main does not count', () => {
     expect(hasMainFunction('fn mainly()')).toBe(false);
   });

--- a/ui/frontend/selectors/index.ts
+++ b/ui/frontend/selectors/index.ts
@@ -121,6 +121,86 @@ const HAS_TESTS_RE = /^\s*#\s*\[\s*test\s*([^"]*)]/m;
 const hasTests = (code: string) => !!code.match(HAS_TESTS_RE);
 const hasTestsSelector = createSelector(allCodeContentsSelector, (f) => f.some(hasTests));
 
+const withoutBlockComments = (code: string) => {
+  const characters = code.split('');
+  let blockDepth = 0;
+  let inLineComment = false;
+  let inString = false;
+  let escaped = false;
+  let rawHashes: number | undefined;
+
+  for (let i = 0; i < characters.length; i += 1) {
+    const current = characters[i];
+    const next = characters[i + 1];
+
+    if (blockDepth > 0) {
+      if (current === '/' && next === '*') {
+        characters[i] = characters[i + 1] = ' ';
+        blockDepth += 1;
+        i += 1;
+      } else if (current === '*' && next === '/') {
+        characters[i] = characters[i + 1] = ' ';
+        blockDepth -= 1;
+        i += 1;
+      } else if (current !== '\n' && current !== '\r') {
+        characters[i] = ' ';
+      }
+      continue;
+    }
+
+    if (inLineComment) {
+      if (current === '\n' || current === '\r') {
+        inLineComment = false;
+      }
+      continue;
+    }
+
+    if (rawHashes !== undefined) {
+      if (
+        current === '"' &&
+        characters.slice(i + 1, i + 1 + rawHashes).join('') === '#'.repeat(rawHashes)
+      ) {
+        i += rawHashes;
+        rawHashes = undefined;
+      }
+      continue;
+    }
+
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (current === '\\') {
+        escaped = true;
+      } else if (current === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (current === '/' && next === '/') {
+      inLineComment = true;
+      i += 1;
+    } else if (current === '/' && next === '*') {
+      characters[i] = characters[i + 1] = ' ';
+      blockDepth = 1;
+      i += 1;
+    } else if (current === 'r') {
+      let end = i + 1;
+      while (characters[end] === '#') {
+        end += 1;
+      }
+      if (characters[end] === '"') {
+        rawHashes = end - i - 1;
+        i = end;
+      }
+    } else if (current === '"') {
+      inString = true;
+    }
+  }
+
+  return characters.join('');
+};
+
 // https://stackoverflow.com/a/34755045/155423
 const HAS_MAIN_FUNCTION_RE = new RegExp(
   [
@@ -130,7 +210,8 @@ const HAS_MAIN_FUNCTION_RE = new RegExp(
   ].map((r) => r.source).join(''),
   'm'
 );
-export const hasMainFunction = (code: string) => !!code.match(HAS_MAIN_FUNCTION_RE);
+export const hasMainFunction = (code: string) =>
+  !!withoutBlockComments(code).match(HAS_MAIN_FUNCTION_RE);
 const hasMainFunctionSelector = createSelector(
   multifileEnabledSelector,
   codeSelector,

--- a/ui/frontend/selectors/index.ts
+++ b/ui/frontend/selectors/index.ts
@@ -121,8 +121,13 @@ const HAS_TESTS_RE = /^\s*#\s*\[\s*test\s*([^"]*)]/m;
 const hasTests = (code: string) => !!code.match(HAS_TESTS_RE);
 const hasTestsSelector = createSelector(allCodeContentsSelector, (f) => f.some(hasTests));
 
-const BLOCK_COMMENT_RE = /^[ \t]*\/\*(?:[^*]|\*(?!\/))*(?:\*\/|$)/gm;
-const withoutBlockComments = (code: string) => code.replace(BLOCK_COMMENT_RE, '');
+const BLOCK_COMMENT_OR_PROTECTED_RE =
+  /(?<protected>\/\/[^\r\n]*|[bc]?"(?:\\[\s\S]|[^"\\])*"|[bc]?r(?<hashes>#{0,255})"[\s\S]*?"\k<hashes>)|(?<blockComment>\/\*(?:[^*]|\*(?!\/))*(?:\*\/|$))/g;
+const withoutBlockComments = (code: string) =>
+  code.replace(
+    BLOCK_COMMENT_OR_PROTECTED_RE,
+    (match, _protected, _hashes, blockComment) => (blockComment ? '' : match),
+  );
 
 // https://stackoverflow.com/a/34755045/155423
 const HAS_MAIN_FUNCTION_RE = new RegExp(

--- a/ui/frontend/selectors/index.ts
+++ b/ui/frontend/selectors/index.ts
@@ -121,85 +121,8 @@ const HAS_TESTS_RE = /^\s*#\s*\[\s*test\s*([^"]*)]/m;
 const hasTests = (code: string) => !!code.match(HAS_TESTS_RE);
 const hasTestsSelector = createSelector(allCodeContentsSelector, (f) => f.some(hasTests));
 
-const withoutBlockComments = (code: string) => {
-  const characters = code.split('');
-  let blockDepth = 0;
-  let inLineComment = false;
-  let inString = false;
-  let escaped = false;
-  let rawHashes: number | undefined;
-
-  for (let i = 0; i < characters.length; i += 1) {
-    const current = characters[i];
-    const next = characters[i + 1];
-
-    if (blockDepth > 0) {
-      if (current === '/' && next === '*') {
-        characters[i] = characters[i + 1] = ' ';
-        blockDepth += 1;
-        i += 1;
-      } else if (current === '*' && next === '/') {
-        characters[i] = characters[i + 1] = ' ';
-        blockDepth -= 1;
-        i += 1;
-      } else if (current !== '\n' && current !== '\r') {
-        characters[i] = ' ';
-      }
-      continue;
-    }
-
-    if (inLineComment) {
-      if (current === '\n' || current === '\r') {
-        inLineComment = false;
-      }
-      continue;
-    }
-
-    if (rawHashes !== undefined) {
-      if (
-        current === '"' &&
-        characters.slice(i + 1, i + 1 + rawHashes).join('') === '#'.repeat(rawHashes)
-      ) {
-        i += rawHashes;
-        rawHashes = undefined;
-      }
-      continue;
-    }
-
-    if (inString) {
-      if (escaped) {
-        escaped = false;
-      } else if (current === '\\') {
-        escaped = true;
-      } else if (current === '"') {
-        inString = false;
-      }
-      continue;
-    }
-
-    if (current === '/' && next === '/') {
-      inLineComment = true;
-      i += 1;
-    } else if (current === '/' && next === '*') {
-      characters[i] = characters[i + 1] = ' ';
-      blockDepth = 1;
-      i += 1;
-    } else if (current === 'r') {
-      let end = i + 1;
-      while (characters[end] === '#') {
-        end += 1;
-      }
-      if (characters[end] === '"') {
-        rawHashes = end - i - 1;
-        i = end;
-      }
-    } else if (current === '"') {
-      inString = true;
-    }
-  }
-
-  return characters.join('');
-};
+const BLOCK_COMMENT_RE = /^[ \t]*\/\*(?:[^*]|\*(?!\/))*(?:\*\/|$)/gm;
+const withoutBlockComments = (code: string) => code.replace(BLOCK_COMMENT_RE, '');
 
 // https://stackoverflow.com/a/34755045/155423
 const HAS_MAIN_FUNCTION_RE = new RegExp(


### PR DESCRIPTION
Block-commented main functions no longer select Run automatically.

This removes multiline and unclosed block comments before applying the existing main-function check. It leaves comment markers inside line comments, normal strings, and raw strings alone.

Fixes #1167
