### PR TITLE
Remove explicit usage of core-js

### DIFF
--- a/ui/frontend/index.tsx
+++ b/ui/frontend/index.tsx
@@ -1,5 +1,3 @@
-import 'core-js';
-
 import 'normalize.css/normalize.css';
 import './index.css';
 

--- a/ui/frontend/package.json
+++ b/ui/frontend/package.json
@@ -8,7 +8,6 @@
     "@reduxjs/toolkit": "^2.0.1",
     "ace-builds": "^1.23.0",
     "common-tags": "^1.8.0",
-    "core-js": "^3.1.3",
     "history": "^5.3.0",
     "immer": "^11.1.3",
     "jotai": "^2.20.0",

--- a/ui/frontend/pnpm-lock.yaml
+++ b/ui/frontend/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       common-tags:
         specifier: ^1.8.0
         version: 1.8.2
-      core-js:
-        specifier: ^3.1.3
-        version: 3.49.0
       history:
         specifier: ^5.3.0
         version: 5.3.0
@@ -4063,7 +4060,8 @@ snapshots:
     dependencies:
       is-what: 4.1.16
 
-  core-js@3.49.0: {}
+  core-js@3.49.0:
+    optional: true
 
   cosmiconfig@9.0.2(typescript@6.0.3):
     dependencies:


### PR DESCRIPTION
To my knowledge, we shouldn't need to include this manually. Rspack's SWC (and Webpack's Babel before that) should be smart enough to inject appropriate core-js polyfills based on our browserlist setting and what code is generated.

Unfortunately, I don't know of a great way of testing this. I expect that most users of the playground are using very modern browsers and I generally try to only use things that are in a previous year's web baseline anyway.

Chances are that only a small percentage of users might ever notice this, but if they do we can add back whatever polyfills are needed.