### PR TITLE
Override WebAssembly compilation options when no crate-type is set

### DIFF
--- a/ui/frontend/actions.ts
+++ b/ui/frontend/actions.ts
@@ -75,8 +75,10 @@ const performCompileToCdylibWasmOnly = (): ThunkAction => (dispatch, getState) =
 
   if (!wasmLikelyToWork(state)) {
     dispatch(addCrateType('cdylib'));
+    dispatch(performCompileToWasmOnly({ crateType: 'cdylib' }));
+  } else {
+    dispatch(performCompileToWasmOnly());
   }
-  dispatch(performCompileToWasmOnly());
 };
 
 const PRIMARY_ACTIONS: { [index in PrimaryAction]: () => ThunkAction } = {

--- a/ui/frontend/compileActions.ts
+++ b/ui/frontend/compileActions.ts
@@ -34,7 +34,7 @@ interface Props {
 
 interface CompileActions {
   action: AsyncThunk<CompileResponseBody, CompileRequestBody, object>;
-  performCompile: () => ThunkAction;
+  performCompile: (overrides?: Partial<CompileRequestBody>) => ThunkAction;
 }
 
 export const makeCompileActions = ({ sliceName, target }: Props): CompileActions => {
@@ -43,11 +43,14 @@ export const makeCompileActions = ({ sliceName, target }: Props): CompileActions
     return CompileResponseBody.parseAsync(d);
   });
 
-  const performCompile = (): ThunkAction => (dispatch, getState) => {
-    const state = getState();
-    const body = compileRequestPayloadSelector(state, { target });
-    dispatch(action(body));
-  };
+  const performCompile =
+    (overrides?: Partial<CompileRequestBody>): ThunkAction =>
+    (dispatch, getState) => {
+      const state = getState();
+      const defaultBody = compileRequestPayloadSelector(state, { target });
+      const body = { ...defaultBody, ...overrides };
+      dispatch(action(body));
+    };
 
   return { action, performCompile };
 };


### PR DESCRIPTION
This should be a no-op for now: we set the crate-type and then build the compilation options based on that new code, which is all synchronous.

In the future, the crate-type will be computed asynchronously, which means that this action will build the options based on the "old" crate-type. Overriding the crate-type at compilation time avoids this.