### PR TITLE
Extract a shared test reducer and DRY up the code

### DIFF
--- a/ui/frontend/reducers/files.spec.ts
+++ b/ui/frontend/reducers/files.spec.ts
@@ -1,24 +1,16 @@
-import { UnknownAction } from '@reduxjs/toolkit';
-
+import { SimpleAction, reduceAll as testReduceAll } from '../testReducer';
 import * as files from './files';
 
-const { default: reducer, ...actions } = files;
-type State = ReturnType<typeof reducer>;
+const { default: _, ...actions } = files;
 
-const reduceAll = (state: State, actions: UnknownAction[]): State => actions.reduce(reducer, state);
+const reduceAll = (actions: SimpleAction[]) => testReduceAll(actions).files;
 
 const expectFileOfName = (name: string) =>
   expect.arrayContaining([expect.objectContaining({ name })]);
 
 describe('modifying the source code', () => {
-  let state: State;
-
-  beforeEach(() => {
-    state = reducer(undefined, { type: '@INIT' });
-  });
-
   test('renaming a directory', () => {
-    state = reduceAll(state, [
+    const state = reduceAll([
       actions.createFile('testing/test.rs'),
       actions.renameDirectory({ from: 'testing', to: 'testing/nested' }),
     ]);
@@ -28,7 +20,7 @@ describe('modifying the source code', () => {
   });
 
   test('renaming a directory with a common prefix', () => {
-    state = reduceAll(state, [
+    const state = reduceAll([
       actions.createFile('test/test.rs'),
       actions.createFile('test1/test.rs'),
       actions.renameDirectory({ from: 'test', to: 'test2' }),
@@ -40,7 +32,7 @@ describe('modifying the source code', () => {
   });
 
   test('renaming a directory that would collide is a no-op', () => {
-    state = reduceAll(state, [
+    const state = reduceAll([
       actions.createFile('a/main.rs'),
       actions.createFile('b/main.rs'),
       actions.renameDirectory({ from: 'a', to: 'b' }),
@@ -51,7 +43,7 @@ describe('modifying the source code', () => {
   });
 
   test('deleting a directory removes all children', () => {
-    state = reduceAll(state, [
+    const state = reduceAll([
       actions.createFile('a.rs'),
       actions.createFile('src/b.rs'),
       actions.createFile('src/c/d.rs'),

--- a/ui/frontend/selectors/gist.spec.ts
+++ b/ui/frontend/selectors/gist.spec.ts
@@ -1,15 +1,11 @@
-import { UnknownAction } from '@reduxjs/toolkit';
-
-import reducer from '../reducers';
 import { editCode } from '../reducers/code';
 import { changeFileView } from '../reducers/configuration';
 import { featureFlagsForceEnableAll } from '../reducers/featureFlags';
 import { activateFile, createFile, deleteFile, renameFile } from '../reducers/files';
 import { performGistLoad } from '../reducers/output/gist';
+import { reduceAll } from '../testReducer';
 import { Channel, Code, Edition, Mode } from '../types';
 import { textChangedSinceShareSelector } from './gist';
-
-type State = ReturnType<typeof reducer>;
 
 const gistLoad = (code: Code) => {
   const arg = {
@@ -24,8 +20,6 @@ const gistLoad = (code: Code) => {
   };
   return performGistLoad.fulfilled(arg, 'request-id', arg);
 };
-
-const reduceAll = (actions: UnknownAction[]): State => actions.reduce(reducer, undefined)!;
 
 describe('checking if the code has changed since it was shared', () => {
   describe('string code, string gist', () => {

--- a/ui/frontend/testReducer.ts
+++ b/ui/frontend/testReducer.ts
@@ -1,0 +1,15 @@
+import { UnknownAction, configureStore } from '@reduxjs/toolkit';
+
+import { ThunkAction } from './actions';
+import reducer from './reducers';
+
+export type SimpleAction = ThunkAction | UnknownAction;
+type State = ReturnType<typeof reducer>;
+
+export const reduceAll = (actions: SimpleAction[]): State => {
+  const store = configureStore({ reducer });
+  for (const action of actions) {
+    store.dispatch(action);
+  }
+  return store.getState();
+};


### PR DESCRIPTION
This reducer is just the logic, with none of the extra listeners or middleware. This also allows the reducer to use thunks.