### PR TITLE
Compress assets with both gzip and brotli

### DIFF
--- a/ui/frontend/rspack.config.mjs
+++ b/ui/frontend/rspack.config.mjs
@@ -134,7 +134,12 @@ module.exports = function (_, argv) {
         filename: `${filenameTemplate}.worker.js`,
         languages: ['rust'],
       }),
-      ...(isProduction ? [new CompressionRspackPlugin()] : []),
+      ...(isProduction
+        ? [
+            new CompressionRspackPlugin({ algorithm: 'gzip' }),
+            new CompressionRspackPlugin({ algorithm: 'brotliCompress' }),
+          ]
+        : []),
     ],
 
     optimization: {

--- a/ui/src/server_axum.rs
+++ b/ui/src/server_axum.rs
@@ -186,7 +186,7 @@ fn get_or_post<T: 'static>(handler: impl Handler<T, ()> + Copy) -> MethodRouter 
 }
 
 fn static_file_service(root: impl AsRef<path::Path>, max_age: HeaderValue) -> MethodRouter {
-    let files = ServeDir::new(root).precompressed_gzip();
+    let files = ServeDir::new(root).precompressed_gzip().precompressed_br();
 
     let with_caching = SetResponseHeader::if_not_present(files, header::CACHE_CONTROL, max_age);
 


### PR DESCRIPTION
Looking at all the assets in the `build/assets` directory, we get a nice savings:

| algorithm    | size (bytes) | percentage |
|--------------|-------------:|-----------:|
| uncompressed |     16464281 |     100.0% |
| gzip         |      3932294 |      23.9% |
| brotli       |      2988588 |      18.2% |