### PR TITLE
Clear out the files when switching to single mode

### DIFF
--- a/ui/frontend/actions.ts
+++ b/ui/frontend/actions.ts
@@ -196,6 +196,7 @@ export function preserveContentAndChangeFileView(fv: FileView): ThunkAction {
     dispatch(changeFileView(fv));
     if (fv === FileView.Single) {
       const code = linearCodeSelector(state);
+      dispatch(files.deleteAll());
       dispatch(editCode(code));
     } else {
       const content = state.code;

--- a/ui/frontend/reducers/files.ts
+++ b/ui/frontend/reducers/files.ts
@@ -239,7 +239,15 @@ export const deleteDirectory =
     dispatch(deleteFileIds(ids));
   };
 
-export const { activateFile, createFile, renameDirectory, renameFile, initializeWith } =
+export const deleteAll = (): ThunkAction => (dispatch, getState) => {
+  const state = getState();
+
+  const ids = state.files.files.map((f) => f.id);
+
+  dispatch(deleteFileIds(ids));
+};
+
+export const { activateFile, createFile, initializeWith, renameDirectory, renameFile } =
   slice.actions;
 
 export default slice.reducer;


### PR DESCRIPTION
Otherwise, when we switch from multiple -> single -> multiple, the previous files still exist and cause the validation step to fail. From the user's POV, this manifests as any edits they made to the single file view are lost.