### PR TITLE
Separate the actions for editing single and multiple files

### DIFF
--- a/ui/frontend/actions.ts
+++ b/ui/frontend/actions.ts
@@ -1,7 +1,7 @@
 import { ThunkAction as ReduxThunkAction, UnknownAction } from '@reduxjs/toolkit';
 
 import { State } from './reducers';
-import { addCrateType, editCode } from './reducers/code';
+import { addCrateType, editSingleCode } from './reducers/code';
 import {
   changeBacktrace,
   changeChannel,
@@ -41,6 +41,17 @@ import {
 } from './types';
 
 export type ThunkAction<T = void> = ReduxThunkAction<T, State, unknown, UnknownAction>;
+
+export const editCode =
+  (code: string): ThunkAction =>
+  (dispatch, getState) => {
+    const state = getState();
+    if (state.configuration.fileView === FileView.Single) {
+      dispatch(editSingleCode(code));
+    } else {
+      dispatch(files.editActiveFile(code));
+    }
+  };
 
 export const reExecuteWithBacktrace = (): ThunkAction => (dispatch) => {
   dispatch(changeBacktrace(Backtrace.Enabled));
@@ -197,7 +208,7 @@ export function preserveContentAndChangeFileView(fv: FileView): ThunkAction {
     if (fv === FileView.Single) {
       const code = linearCodeSelector(state);
       dispatch(files.deleteAll());
-      dispatch(editCode(code));
+      dispatch(editSingleCode(code));
     } else {
       const content = state.code;
       const name = hasMainFunction(content) ? 'src/main.rs' : 'src/lib.rs';

--- a/ui/frontend/editor/Editor.tsx
+++ b/ui/frontend/editor/Editor.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 
 import * as actions from '../actions';
 import { useAppDispatch, useAppSelector } from '../hooks';
-import { editCode } from '../reducers/code';
 import * as config from '../reducers/configuration';
 import * as files from '../reducers/files';
 import { activeCodeSelector, positionSelector, selectionSelector } from '../selectors';
@@ -81,7 +80,7 @@ const Editor: React.FC = () => {
         crates={crates}
         activeFileId={activeFileId}
         fileIds={fileIds}
-        onEditCode={(c) => dispatch(editCode(c))}
+        onEditCode={(c) => dispatch(actions.editCode(c))}
         execute={() => dispatch(actions.performPrimaryAction())}
       />
     </div>

--- a/ui/frontend/index.tsx
+++ b/ui/frontend/index.tsx
@@ -7,6 +7,7 @@ import { Provider } from 'react-redux';
 import { v4 } from 'uuid';
 
 import {
+  editCode,
   reExecuteWithBacktrace,
 } from './actions';
 import { configureRustErrors } from './highlighting';
@@ -20,7 +21,7 @@ import configureStore from './configureStore';
 import { performVersionsLoad } from './reducers/versions';
 import { performCratesLoad } from './reducers/crates';
 import { gotoPosition } from './reducers/position';
-import { addImport, editCode, enableFeatureGate } from './reducers/code';
+import { addImport, enableFeatureGate } from './reducers/code';
 import { browserWidthChanged } from './reducers/browser';
 import { selectText } from './reducers/selection';
 import { useAppSelector } from './hooks';

--- a/ui/frontend/reducers/code.ts
+++ b/ui/frontend/reducers/code.ts
@@ -14,7 +14,7 @@ const slice = createSlice({
   name: 'code',
   initialState: HELLO_WORLD,
   reducers: {
-    editCode: (_state, action: PayloadAction<string>) => action.payload,
+    editSingleCode: (_state, action: PayloadAction<string>) => action.payload,
 
     addMainFunction: (state) => `${state}\n\n${HELLO_WORLD}`,
 
@@ -45,7 +45,7 @@ const slice = createSlice({
   },
 });
 
-export const { editCode, addMainFunction, addImport, addCrateType, enableFeatureGate } =
+export const { editSingleCode, addMainFunction, addImport, addCrateType, enableFeatureGate } =
   slice.actions;
 
 export default slice.reducer;

--- a/ui/frontend/reducers/files.ts
+++ b/ui/frontend/reducers/files.ts
@@ -9,7 +9,7 @@ import {
   validateFilename,
 } from '../domain/filesRules';
 import { FileId } from '../types';
-import { HELLO_WORLD, addCrateType, addMainFunction, doAddCrateType, editCode } from './code';
+import { HELLO_WORLD, addCrateType, addMainFunction, doAddCrateType } from './code';
 import { performFormat } from './output/format';
 import { performGistLoad } from './output/gist';
 
@@ -93,6 +93,13 @@ const slice = createSlice({
       state.active = newFile.id;
     },
 
+    editActiveFile: (state, action: PayloadAction<string>) => {
+      const file = state.files.find((f) => f.id === state.active);
+      if (file) {
+        file.content = action.payload;
+      }
+    },
+
     createFile: (state, action: PayloadAction<string>) => {
       const candidateName = action.payload;
 
@@ -163,12 +170,6 @@ const slice = createSlice({
   },
   extraReducers: (builder) => {
     builder
-      .addCase(editCode, (state, action) => {
-        const file = state.files.find((f) => f.id === state.active);
-        if (file) {
-          file.content = action.payload;
-        }
-      })
       .addCase(addMainFunction, (state) => {
         const existing = state.files.find((f) => f.name === 'src/main.rs');
 
@@ -247,7 +248,13 @@ export const deleteAll = (): ThunkAction => (dispatch, getState) => {
   dispatch(deleteFileIds(ids));
 };
 
-export const { activateFile, createFile, initializeWith, renameDirectory, renameFile } =
-  slice.actions;
+export const {
+  activateFile,
+  createFile,
+  editActiveFile,
+  initializeWith,
+  renameDirectory,
+  renameFile,
+} = slice.actions;
 
 export default slice.reducer;

--- a/ui/frontend/selectors/gist.spec.ts
+++ b/ui/frontend/selectors/gist.spec.ts
@@ -1,4 +1,4 @@
-import { editCode } from '../reducers/code';
+import { editCode } from '../actions';
 import { changeFileView } from '../reducers/configuration';
 import { featureFlagsForceEnableAll } from '../reducers/featureFlags';
 import { activateFile, createFile, deleteFile, renameFile } from '../reducers/files';


### PR DESCRIPTION
Now we will skip updating the single file content when editing in the multiple file mode.