### PR TITLE
Move the editor's ruler to where rustfmt will wrap

### DIFF
--- a/ui/frontend/editor/AceEditorCore.tsx
+++ b/ui/frontend/editor/AceEditorCore.tsx
@@ -8,6 +8,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { CommonEditorProps, Crate, FileId, PairCharacters, Position } from '../types';
 import { useLatest } from './useLatest';
+import { RUSTFMT_DEFAULT_MAX_WIDTH } from './common';
 
 import * as styles from './Editor.module.css';
 
@@ -141,6 +142,7 @@ const AceEditor: React.FC<AceEditorProps> = props => {
     editor.setOptions({
       enableBasicAutocompletion: true,
       fixedWidthGutter: true,
+      printMargin: RUSTFMT_DEFAULT_MAX_WIDTH,
     });
 
     return () => {

--- a/ui/frontend/editor/MonacoEditorCore.tsx
+++ b/ui/frontend/editor/MonacoEditorCore.tsx
@@ -4,6 +4,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useAppSelector } from '../hooks';
 import { offerCrateAutocompleteOnUse } from '../selectors';
 import { CommonEditorProps, FileId } from '../types';
+import { RUSTFMT_DEFAULT_MAX_WIDTH } from './common';
 import { themeVsDarkPlus } from './rust_monaco_def';
 import { useLatest } from './useLatest';
 
@@ -102,6 +103,7 @@ const MonacoEditorCore: React.FC<CommonEditorProps> = (props) => {
         automaticLayout: true,
         'semanticHighlighting.enabled': true,
         autoClosingOvertype: 'always',
+        rulers: [RUSTFMT_DEFAULT_MAX_WIDTH],
       });
       setEditor(editor);
 

--- a/ui/frontend/editor/common.ts
+++ b/ui/frontend/editor/common.ts
@@ -1,0 +1,2 @@
+// https://rust-lang.github.io/rustfmt/?version=v1.10.0&search=#max_width
+export const RUSTFMT_DEFAULT_MAX_WIDTH = 100;


### PR DESCRIPTION
This also turns on the ruler for Monaco in the first place.

We are picking the value from the current version of rustfmt, but I don't think it changes too often.

Closes #1264